### PR TITLE
Fix invalid Image lock calls

### DIFF
--- a/scripts/Card.gd
+++ b/scripts/Card.gd
@@ -14,7 +14,6 @@ func _create_card_texture() -> ImageTexture:
     var height := 150
     var img := Image.create(width, height, false, Image.FORMAT_RGBA8)
     img.fill(Color(1, 1, 1, 1))
-    img.lock()
     var black := Color(0, 0, 0, 1)
 
     for y in range(30, height - 20):
@@ -23,7 +22,6 @@ func _create_card_texture() -> ImageTexture:
     for x in range(width / 2 - 10, width / 2 + 10):
         img.set_pixel(x, 30, black)
 
-    img.unlock()
     var tex := ImageTexture.create_from_image(img)
     return tex
 


### PR DESCRIPTION
## Summary
- remove deprecated `Image.lock()` and `Image.unlock()` usage

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68437fb30820832e874f4287e356f277