### PR TITLE
Fix card reset position

### DIFF
--- a/scripts/Card.gd
+++ b/scripts/Card.gd
@@ -16,6 +16,9 @@ func _ready():
     sprite.centered = true
     add_child(sprite)
 
+func set_original_position():
+    original_position = position
+
 func _input(event):
     if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
         var mouse_pos = get_global_mouse_position()
@@ -24,6 +27,7 @@ func _input(event):
             if rect.has_point(mouse_pos):
                 is_dragging = true
                 drag_offset = position - mouse_pos
+                original_position = position
         elif !event.pressed and is_dragging:
             is_dragging = false
             position = original_position

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -5,4 +5,5 @@ func _ready():
     var card := card_scene.instantiate()
     add_child(card)
     card.position = get_viewport_rect().size / 2
+    card.set_original_position()
 


### PR DESCRIPTION
## Summary
- keep track of the card's original spot once it has been positioned
- ensure the card returns to that position after dragging

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684381bc2148832ea5b7fdb080cf4363