### PR TITLE
Spawn five cards at start

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -2,8 +2,13 @@ extends Node2D
 
 func _ready():
     var card_scene := preload("res://scenes/Card.tscn")
-    var card := card_scene.instantiate()
-    add_child(card)
-    card.position = get_viewport_rect().size / 2
-    card.set_original_position()
+    var viewport_size := get_viewport_rect().size
+    var num_cards := 5
+    var spacing := viewport_size.x / (num_cards + 1)
+
+    for i in range(num_cards):
+        var card := card_scene.instantiate()
+        add_child(card)
+        card.position = Vector2(spacing * (i + 1), viewport_size.y / 2)
+        card.set_original_position()
 


### PR DESCRIPTION
## Summary
- spawn five Card instances instead of one
- position them evenly across the viewport

## Testing
- `godot` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684383569a4c832e91769aea2294385d