### PR TITLE
Move cards lower on screen

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -11,7 +11,7 @@ func _ready():
         add_child(card)
         card.position = Vector2(
             spacing * (i + 1),
-            viewport_size.y * 2.0 / 3.0
+            viewport_size.y * 5.0 / 6.0
         )
         card.set_original_position()
 


### PR DESCRIPTION
## Summary
- adjust Y position for cards so they appear lower on screen

## Testing
- `godot` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843855fdfd0832eba31e421730e309d