### PR TITLE
Add random tetris starting hand

### DIFF
--- a/scripts/Card.gd
+++ b/scripts/Card.gd
@@ -4,23 +4,36 @@ class_name Card
 var card_name: String = ""
 var value: int = 1
 
+# Name of the tetris shape for this card
+var shape_name: String = "L"
+
 var sprite: Sprite2D
 var size := Vector2(100, 150)
 var card_texture: ImageTexture
 var piece_texture: ImageTexture
+var piece_size: Vector2
 var is_transformed := false
 var original_position: Vector2
 var is_dragging := false
 var drag_offset := Vector2.ZERO
 
+const BLOCK_SIZE := 20
+const SHAPE_DATA := {
+    "I": [Vector2(0,0), Vector2(1,0), Vector2(2,0), Vector2(3,0)],
+    "L": [Vector2(0,0), Vector2(0,1), Vector2(0,2), Vector2(1,2)],
+    "O": [Vector2(0,0), Vector2(1,0), Vector2(0,1), Vector2(1,1)],
+    "T": [Vector2(1,0), Vector2(0,1), Vector2(1,1), Vector2(2,1)],
+    "S": [Vector2(1,0), Vector2(2,0), Vector2(0,1), Vector2(1,1)],
+    "Z": [Vector2(0,0), Vector2(1,0), Vector2(1,1), Vector2(2,1)]
+}
+
 func _ready():
     original_position = position
     sprite = Sprite2D.new()
-    card_texture = _create_card_texture()
-    piece_texture = _create_piece_texture()
+    add_child(sprite)
+    _update_textures()
     sprite.texture = card_texture
     sprite.centered = true
-    add_child(sprite)
 
 func set_original_position():
     original_position = position
@@ -46,58 +59,64 @@ func _process(delta):
     if is_dragging:
         position = get_global_mouse_position() + drag_offset
 
-func _create_card_texture() -> ImageTexture:
+func _update_textures():
+    var blocks = SHAPE_DATA.get(shape_name, SHAPE_DATA["L"])
+    card_texture = _create_card_texture(blocks)
+    piece_texture = _create_piece_texture(blocks)
+
+func _create_card_texture(blocks: Array) -> ImageTexture:
     var width := 100
     var height := 150
     var img := Image.create(width, height, false, Image.FORMAT_RGBA8)
     img.fill(Color(1, 1, 1, 1))
     var black := Color(0, 0, 0, 1)
 
-    var block_size := 20
-    var start_x := int((width - block_size * 2) / 2)
-    var start_y := int((height - block_size * 3) / 2)
-    var blocks := [
-        Vector2(0, 0),
-        Vector2(0, 1),
-        Vector2(0, 2),
-        Vector2(1, 2)
-    ]
+    var bounds := _get_shape_bounds(blocks)
+    var shape_w := int(bounds.size.x) * BLOCK_SIZE
+    var shape_h := int(bounds.size.y) * BLOCK_SIZE
+    var start_x := int((width - shape_w) / 2) - int(bounds.position.x) * BLOCK_SIZE
+    var start_y := int((height - shape_h) / 2) - int(bounds.position.y) * BLOCK_SIZE
 
     for block in blocks:
-        for x in range(block_size):
-            for y in range(block_size):
-                var px: int = start_x + int(block.x) * block_size + x
-                var py: int = start_y + int(block.y) * block_size + y
+        for x in range(BLOCK_SIZE):
+            for y in range(BLOCK_SIZE):
+                var px: int = start_x + int(block.x) * BLOCK_SIZE + x
+                var py: int = start_y + int(block.y) * BLOCK_SIZE + y
                 img.set_pixel(px, py, black)
 
-    var tex := ImageTexture.create_from_image(img)
-    return tex
+    return ImageTexture.create_from_image(img)
 
-func _create_piece_texture() -> ImageTexture:
-    var block_size := 20
-    var width := block_size * 2
-    var height := block_size * 3
+func _create_piece_texture(blocks: Array) -> ImageTexture:
+    var bounds := _get_shape_bounds(blocks)
+    var width := int(bounds.size.x) * BLOCK_SIZE
+    var height := int(bounds.size.y) * BLOCK_SIZE
     var img := Image.create(width, height, false, Image.FORMAT_RGBA8)
     img.fill(Color(0, 0, 0, 0))
     var black := Color(0, 0, 0, 1)
-    var blocks := [
-        Vector2(0, 0),
-        Vector2(0, 1),
-        Vector2(0, 2),
-        Vector2(1, 2)
-    ]
     for block in blocks:
-        for x in range(block_size):
-            for y in range(block_size):
-                var px: int = int(block.x) * block_size + x
-                var py: int = int(block.y) * block_size + y
+        for x in range(BLOCK_SIZE):
+            for y in range(BLOCK_SIZE):
+                var px: int = (int(block.x) - int(bounds.position.x)) * BLOCK_SIZE + x
+                var py: int = (int(block.y) - int(bounds.position.y)) * BLOCK_SIZE + y
                 img.set_pixel(px, py, black)
-    var tex := ImageTexture.create_from_image(img)
-    return tex
+    piece_size = Vector2(width, height)
+    return ImageTexture.create_from_image(img)
+
+func _get_shape_bounds(blocks: Array) -> Rect2:
+    var min_x := blocks[0].x
+    var max_x := blocks[0].x
+    var min_y := blocks[0].y
+    var max_y := blocks[0].y
+    for b in blocks:
+        min_x = min(min_x, b.x)
+        max_x = max(max_x, b.x)
+        min_y = min(min_y, b.y)
+        max_y = max(max_y, b.y)
+    return Rect2(min_x, min_y, max_x - min_x + 1, max_y - min_y + 1)
 
 func _transform_to_piece():
     sprite.texture = piece_texture
-    size = Vector2(40, 60)
+    size = piece_size
     is_transformed = true
 
 func _transform_to_card():
@@ -108,5 +127,4 @@ func _transform_to_card():
 func _is_in_bottom_third() -> bool:
     var viewport_size := get_viewport_rect().size
     return original_position.y > viewport_size.y * 2.0 / 3.0
-
 

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -3,15 +3,22 @@ extends Node2D
 var _cards: Array[Card] = []
 var _previous_viewport_size := Vector2.ZERO
 
+const SHAPES := ["I", "L", "O", "T", "S", "Z"]
+
 func _ready():
     var card_scene := preload("res://scenes/Card.tscn")
     _previous_viewport_size = get_viewport_rect().size
     var viewport_size := _previous_viewport_size
-    var num_cards := 5
+
+    var available := SHAPES.duplicate()
+    available.shuffle()
+    var selected := available.slice(0, 5)
+    var num_cards := selected.size()
     var spacing := viewport_size.x / (num_cards + 1)
 
     for i in range(num_cards):
         var card := card_scene.instantiate()
+        card.shape_name = selected[i]
         add_child(card)
         _cards.append(card)
         var bottom_y: float = viewport_size.y - card.size.y / 2.0 - 10.0


### PR DESCRIPTION
## Summary
- add shape selection and piece texture generation for cards
- pick a random set of tetris shapes to build the starting hand

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445d1ed794832e9a4392d33abbafcb