### PR TITLE
Fix typed array assignment error

### DIFF
--- a/scripts/Card.gd
+++ b/scripts/Card.gd
@@ -60,7 +60,7 @@ func _process(delta):
         position = get_global_mouse_position() + drag_offset
 
 func _update_textures():
-    var blocks: Array[Vector2] = SHAPE_DATA.get(shape_name, SHAPE_DATA["L"])
+    var blocks: Array[Vector2] = SHAPE_DATA.get(shape_name, SHAPE_DATA["L"]) as Array[Vector2]
     card_texture = _create_card_texture(blocks)
     piece_texture = _create_piece_texture(blocks)
 


### PR DESCRIPTION
## Summary
- cast SHAPE_DATA arrays to `Array[Vector2]`

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445ec6fbf0832eadf1547fb87d663d