### PR TITLE
Fix typed array error in card textures

### DIFF
--- a/scripts/Card.gd
+++ b/scripts/Card.gd
@@ -19,12 +19,12 @@ var drag_offset := Vector2.ZERO
 
 const BLOCK_SIZE := 20
 const SHAPE_DATA := {
-    "I": [Vector2(0,0), Vector2(1,0), Vector2(2,0), Vector2(3,0)],
-    "L": [Vector2(0,0), Vector2(0,1), Vector2(0,2), Vector2(1,2)],
-    "O": [Vector2(0,0), Vector2(1,0), Vector2(0,1), Vector2(1,1)],
-    "T": [Vector2(1,0), Vector2(0,1), Vector2(1,1), Vector2(2,1)],
-    "S": [Vector2(1,0), Vector2(2,0), Vector2(0,1), Vector2(1,1)],
-    "Z": [Vector2(0,0), Vector2(1,0), Vector2(1,1), Vector2(2,1)]
+    "I": [Vector2(0,0), Vector2(1,0), Vector2(2,0), Vector2(3,0)] as Array[Vector2],
+    "L": [Vector2(0,0), Vector2(0,1), Vector2(0,2), Vector2(1,2)] as Array[Vector2],
+    "O": [Vector2(0,0), Vector2(1,0), Vector2(0,1), Vector2(1,1)] as Array[Vector2],
+    "T": [Vector2(1,0), Vector2(0,1), Vector2(1,1), Vector2(2,1)] as Array[Vector2],
+    "S": [Vector2(1,0), Vector2(2,0), Vector2(0,1), Vector2(1,1)] as Array[Vector2],
+    "Z": [Vector2(0,0), Vector2(1,0), Vector2(1,1), Vector2(2,1)] as Array[Vector2]
 }
 
 func _ready():
@@ -60,7 +60,7 @@ func _process(delta):
         position = get_global_mouse_position() + drag_offset
 
 func _update_textures():
-    var blocks: Array[Vector2] = SHAPE_DATA.get(shape_name, SHAPE_DATA["L"]) as Array[Vector2]
+    var blocks: Array[Vector2] = SHAPE_DATA.get(shape_name, SHAPE_DATA["L"])
     card_texture = _create_card_texture(blocks)
     piece_texture = _create_piece_texture(blocks)
 


### PR DESCRIPTION
## Summary
- type the shape data dictionary so each entry is an `Array[Vector2]`
- remove unsafe `as Array[Vector2]` cast when fetching blocks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68445f65722c832eb6e7984ac01bdafb