### PR TITLE
Fix constant expression error for shape data

### DIFF
--- a/scripts/Card.gd
+++ b/scripts/Card.gd
@@ -18,7 +18,11 @@ var is_dragging := false
 var drag_offset := Vector2.ZERO
 
 const BLOCK_SIZE := 20
-const SHAPE_DATA := {
+## Dictionary containing the coordinates for each tetromino.
+# Using `var` instead of `const` avoids the constant-expression error when
+# running on versions of Godot that do not treat `Vector2` constructors as
+# compile-time constants.
+var SHAPE_DATA := {
     "I": [Vector2(0,0), Vector2(1,0), Vector2(2,0), Vector2(3,0)],
     "L": [Vector2(0,0), Vector2(0,1), Vector2(0,2), Vector2(1,2)],
     "O": [Vector2(0,0), Vector2(1,0), Vector2(0,1), Vector2(1,1)],


### PR DESCRIPTION
## Summary
- avoid Godot constant expression issue by changing `SHAPE_DATA` to a variable
- add a comment describing the reason for the change

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844628b46f8832e842d252522e09739