### PR TITLE
Fix type inference warning

### DIFF
--- a/scripts/Card.gd
+++ b/scripts/Card.gd
@@ -64,7 +64,7 @@ func _process(delta):
         position = get_global_mouse_position() + drag_offset
 
 func _update_textures():
-    var shape_blocks := SHAPE_DATA.get(shape_name, SHAPE_DATA["L"])
+    var shape_blocks: Array = SHAPE_DATA.get(shape_name, SHAPE_DATA["L"])
     var blocks: Array[Vector2] = []
     blocks.assign(shape_blocks)
     card_texture = _create_card_texture(blocks)


### PR DESCRIPTION
## Summary
- avoid Variant inference when retrieving card shape data

## Testing
- `echo "No tests available"`

------
https://chatgpt.com/codex/tasks/task_e_68446cb1cd40832e9f6f6a3837c7298e