### PR TITLE
Refactor Godot card scripts

### DIFF
--- a/scripts/Card.gd
+++ b/scripts/Card.gd
@@ -8,7 +8,10 @@ var value: int = 1
 var shape_name: String = "L"
 
 var sprite: Sprite2D
-var size := Vector2(100, 150)
+const CARD_WIDTH := 100
+const CARD_HEIGHT := 150
+const CARD_SIZE := Vector2(CARD_WIDTH, CARD_HEIGHT)
+var size := CARD_SIZE
 var card_texture: ImageTexture
 var piece_texture: ImageTexture
 var piece_size: Vector2
@@ -71,8 +74,8 @@ func _update_textures():
     piece_texture = _create_piece_texture(blocks)
 
 func _create_card_texture(blocks: Array[Vector2]) -> ImageTexture:
-    var width := 100
-    var height := 150
+    var width := CARD_WIDTH
+    var height := CARD_HEIGHT
     var img := Image.create(width, height, false, Image.FORMAT_RGBA8)
     img.fill(Color(1, 1, 1, 1))
     var black := Color(0, 0, 0, 1)
@@ -127,7 +130,7 @@ func _transform_to_piece():
 
 func _transform_to_card():
     sprite.texture = card_texture
-    size = Vector2(100, 150)
+    size = CARD_SIZE
     is_transformed = false
 
 func _is_in_bottom_third() -> bool:

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -4,29 +4,23 @@ var _cards: Array[Card] = []
 var _previous_viewport_size := Vector2.ZERO
 
 const SHAPES := ["I", "L", "O", "T", "S", "Z"]
+const CARD_SCENE := preload("res://scenes/Card.tscn")
+const BOTTOM_MARGIN := 10.0
 
 func _ready():
-    var card_scene := preload("res://scenes/Card.tscn")
     _previous_viewport_size = get_viewport_rect().size
-    var viewport_size := _previous_viewport_size
 
     var available := SHAPES.duplicate()
     available.shuffle()
     var selected := available.slice(0, 5)
-    var num_cards := selected.size()
-    var spacing := viewport_size.x / (num_cards + 1)
 
-    for i in range(num_cards):
-        var card := card_scene.instantiate()
-        card.shape_name = selected[i]
+    for shape in selected:
+        var card := CARD_SCENE.instantiate()
+        card.shape_name = shape
         add_child(card)
         _cards.append(card)
-        var bottom_y: float = viewport_size.y - card.size.y / 2.0 - 10.0
-        card.position = Vector2(
-            spacing * (i + 1),
-            bottom_y
-        )
-        card.set_original_position()
+
+    _update_card_positions()
 
 func _process(delta):
     var current_size := get_viewport_rect().size
@@ -40,10 +34,7 @@ func _update_card_positions():
     var spacing := viewport_size.x / (num_cards + 1)
     for i in range(num_cards):
         var card := _cards[i]
-        var bottom_y: float = viewport_size.y - card.size.y / 2.0 - 10.0
-        card.position = Vector2(
-            spacing * (i + 1),
-            bottom_y
-        )
+        var bottom_y: float = viewport_size.y - card.size.y / 2.0 - BOTTOM_MARGIN
+        card.position = Vector2(spacing * (i + 1), bottom_y)
         card.set_original_position()
 


### PR DESCRIPTION
## Summary
- preload the card scene once and compute card positions with a helper
- store card dimensions as constants for reuse
- tweak card positioning logic

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449623ddd8832e98573f33d46c5039