### PR TITLE
Add grid placement for tetris pieces

### DIFF
--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,7 +1,16 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://scripts/Main.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/Grid.gd" id="2"]
 
 [node name="Main" type="Node2D"]
 
 script = ExtResource("1")
+
+[node name="LeftGrid" type="Node2D" parent="."]
+
+script = ExtResource("2")
+
+[node name="RightGrid" type="Node2D" parent="."]
+
+script = ExtResource("2")

--- a/scripts/Card.gd
+++ b/scripts/Card.gd
@@ -19,6 +19,7 @@ var is_transformed := false
 var original_position: Vector2
 var is_dragging := false
 var drag_offset := Vector2.ZERO
+var shape_bounds := Rect2()
 
 const BLOCK_SIZE := 20
 ## Dictionary containing the coordinates for each tetromino.
@@ -58,9 +59,13 @@ func _input(event):
                     _transform_to_piece()
         elif !event.pressed and is_dragging:
             is_dragging = false
-            position = original_position
             if is_transformed:
+                var parent = get_parent()
+                if parent and parent.has_method("on_card_dropped"):
+                    if parent.on_card_dropped(self):
+                        return
                 _transform_to_card()
+            position = original_position
 
 func _process(delta):
     if is_dragging:
@@ -70,6 +75,7 @@ func _update_textures():
     var shape_blocks: Array = SHAPE_DATA.get(shape_name, SHAPE_DATA["L"])
     var blocks: Array[Vector2] = []
     blocks.assign(shape_blocks)
+    shape_bounds = _get_shape_bounds(blocks)
     card_texture = _create_card_texture(blocks)
     piece_texture = _create_piece_texture(blocks)
 
@@ -136,4 +142,14 @@ func _transform_to_card():
 func _is_in_bottom_third() -> bool:
     var viewport_size := get_viewport_rect().size
     return original_position.y > viewport_size.y * 2.0 / 3.0
+
+func get_global_block_positions() -> Array[Vector2]:
+    var blocks: Array = SHAPE_DATA.get(shape_name, SHAPE_DATA["L"])
+    var top_left := position - size / 2.0
+    var positions: Array[Vector2] = []
+    for b in blocks:
+        var px := top_left.x + (b.x - shape_bounds.position.x) * BLOCK_SIZE
+        var py := top_left.y + (b.y - shape_bounds.position.y) * BLOCK_SIZE
+        positions.append(Vector2(px, py))
+    return positions
 

--- a/scripts/Grid.gd
+++ b/scripts/Grid.gd
@@ -1,0 +1,48 @@
+extends Node2D
+class_name Grid
+
+const COLS := 10
+const ROWS := 20
+const CELL_SIZE := 20
+
+var cells: Array = []
+
+func _ready():
+    for x in range(COLS):
+        cells.append([])
+        for y in range(ROWS):
+            cells[x].append(false)
+    update()
+
+func _draw():
+    var width := COLS * CELL_SIZE
+    var height := ROWS * CELL_SIZE
+    var line_color := Color(0.7, 0.7, 0.7)
+    for x in range(COLS + 1):
+        draw_line(Vector2(x * CELL_SIZE, 0), Vector2(x * CELL_SIZE, height), line_color)
+    for y in range(ROWS + 1):
+        draw_line(Vector2(0, y * CELL_SIZE), Vector2(width, y * CELL_SIZE), line_color)
+    var fill_color := Color(0, 0, 0)
+    for x in range(COLS):
+        for y in range(ROWS):
+            if cells[x][y]:
+                draw_rect(Rect2(x * CELL_SIZE, y * CELL_SIZE, CELL_SIZE, CELL_SIZE), fill_color)
+
+func try_place_piece(card) -> bool:
+    if not card.has_method("get_global_block_positions"):
+        return false
+    var positions := card.get_global_block_positions()
+    var indices := []
+    for pos in positions:
+        var local := to_local(pos)
+        var ix := int(floor(local.x / CELL_SIZE))
+        var iy := int(floor(local.y / CELL_SIZE))
+        if ix < 0 or ix >= COLS or iy < 0 or iy >= ROWS:
+            return false
+        if cells[ix][iy]:
+            return false
+        indices.append(Vector2i(ix, iy))
+    for idx in indices:
+        cells[idx.x][idx.y] = true
+    update()
+    return true

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -2,13 +2,17 @@ extends Node2D
 
 var _cards: Array[Card] = []
 var _previous_viewport_size := Vector2.ZERO
+var _grids: Array[Grid] = []
 
 const SHAPES := ["I", "L", "O", "T", "S", "Z"]
 const CARD_SCENE := preload("res://scenes/Card.tscn")
 const BOTTOM_MARGIN := 10.0
+const GRID_MARGIN := 20.0
 
 func _ready():
     _previous_viewport_size = get_viewport_rect().size
+    _grids = [get_node("LeftGrid"), get_node("RightGrid")]
+    _position_grids()
 
     var available := SHAPES.duplicate()
     available.shuffle()
@@ -27,6 +31,7 @@ func _process(delta):
     if current_size != _previous_viewport_size:
         _previous_viewport_size = current_size
         _update_card_positions()
+        _position_grids()
 
 func _update_card_positions():
     var viewport_size := _previous_viewport_size
@@ -37,4 +42,24 @@ func _update_card_positions():
         var bottom_y: float = viewport_size.y - card.size.y / 2.0 - BOTTOM_MARGIN
         card.position = Vector2(spacing * (i + 1), bottom_y)
         card.set_original_position()
+
+func _position_grids():
+    if _grids.size() < 2:
+        return
+    var viewport_size := _previous_viewport_size
+    var grid_width := Grid.COLS * Grid.CELL_SIZE
+    var top_y := GRID_MARGIN
+    var left_x := GRID_MARGIN
+    _grids[0].position = Vector2(left_x, top_y)
+    var right_x := viewport_size.x - grid_width - GRID_MARGIN
+    _grids[1].position = Vector2(right_x, top_y)
+
+func on_card_dropped(card: Card) -> bool:
+    for grid in _grids:
+        if grid.try_place_piece(card):
+            _cards.erase(card)
+            card.queue_free()
+            _update_card_positions()
+            return true
+    return false
 


### PR DESCRIPTION
## Summary
- add `Grid` node script for storing and drawing grid cells
- create left and right grids in Main scene
- position grids and handle dropping cards into grids
- allow cards to report block positions and interact with grids

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844980e69dc832ebd535a3f95f103e9