### PR TITLE
Add ghost preview for tetris piece placement

### DIFF
--- a/scripts/Card.gd
+++ b/scripts/Card.gd
@@ -70,6 +70,13 @@ func _input(event):
 func _process(delta):
     if is_dragging:
         position = get_global_mouse_position() + drag_offset
+        var parent = get_parent()
+        if parent and parent.has_method("preview_card_drag"):
+            parent.preview_card_drag(self)
+    else:
+        var parent = get_parent()
+        if parent and parent.has_method("clear_previews"):
+            parent.clear_previews()
 
 func _update_textures():
     var shape_blocks: Array = SHAPE_DATA.get(shape_name, SHAPE_DATA["L"])

--- a/scripts/Grid.gd
+++ b/scripts/Grid.gd
@@ -6,6 +6,7 @@ const ROWS := 20
 const CELL_SIZE := 20
 
 var cells: Array = []
+var preview_cells: Array[Vector2i] = []
 
 func _ready():
     for x in range(COLS):
@@ -27,6 +28,9 @@ func _draw():
         for y in range(ROWS):
             if cells[x][y]:
                 draw_rect(Rect2(x * CELL_SIZE, y * CELL_SIZE, CELL_SIZE, CELL_SIZE), fill_color)
+    var preview_color := Color(0, 0, 1, 0.5)
+    for idx in preview_cells:
+        draw_rect(Rect2(idx.x * CELL_SIZE, idx.y * CELL_SIZE, CELL_SIZE, CELL_SIZE), preview_color)
 
 func try_place_piece(card) -> bool:
     if not card.has_method("get_global_block_positions"):
@@ -46,3 +50,28 @@ func try_place_piece(card) -> bool:
         cells[idx.x][idx.y] = true
     queue_redraw()
     return true
+
+func preview_piece(card) -> void:
+    preview_cells.clear()
+    if not card.has_method("get_global_block_positions"):
+        queue_redraw()
+        return
+    var positions: Array[Vector2] = card.get_global_block_positions()
+    for pos in positions:
+        var local := to_local(pos)
+        var ix := int(floor(local.x / CELL_SIZE))
+        var iy := int(floor(local.y / CELL_SIZE))
+        if ix < 0 or ix >= COLS or iy < 0 or iy >= ROWS:
+            queue_redraw()
+            return
+        if cells[ix][iy]:
+            queue_redraw()
+            return
+        preview_cells.append(Vector2i(ix, iy))
+    queue_redraw()
+
+func clear_preview() -> void:
+    if preview_cells.is_empty():
+        return
+    preview_cells.clear()
+    queue_redraw()

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -60,6 +60,16 @@ func on_card_dropped(card: Card) -> bool:
             _cards.erase(card)
             card.queue_free()
             _update_card_positions()
+            clear_previews()
             return true
+    clear_previews()
     return false
+
+func preview_card_drag(card: Card) -> void:
+    for grid in _grids:
+        grid.preview_piece(card)
+
+func clear_previews() -> void:
+    for grid in _grids:
+        grid.clear_preview()
 


### PR DESCRIPTION
## Summary
- show highlighted cells for piece placement in `Grid`
- preview placement when dragging cards in `Main` and `Card`

## Testing
- `godot --headless --quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449afbf890832e8e68a785f2f13276