### PR TITLE
Fix script static access and typing

### DIFF
--- a/scripts/Card.gd
+++ b/scripts/Card.gd
@@ -24,9 +24,11 @@ static func update_scale(new_cell_size: float) -> void:
     var scale := new_cell_size / BASE_BLOCK_SIZE
     card_width = int(BASE_CARD_WIDTH * scale)
     card_height = int(BASE_CARD_HEIGHT * scale)
-    for c in get_tree().get_nodes_in_group("Cards"):
-        if c is Card:
-            c._update_textures()
+    var tree := Engine.get_main_loop()
+    if tree is SceneTree:
+        for c in tree.get_nodes_in_group("Cards"):
+            if c is Card:
+                c._update_textures()
 
 var size := Vector2(card_width, card_height)
 var card_texture: ImageTexture

--- a/scripts/Grid.gd
+++ b/scripts/Grid.gd
@@ -12,10 +12,12 @@ static var CELL_SIZE := BASE_CELL_SIZE
 
 static func set_cell_size(new_size: float) -> void:
     CELL_SIZE = new_size
-    # Redraw all existing grid instances when the cell size changes
-    for grid in get_tree().get_nodes_in_group("GridInstances"):
-        if grid is Grid:
-            grid.queue_redraw()
+    # Redraw all existing grid instances when the cell size changes.
+    var tree := Engine.get_main_loop()
+    if tree is SceneTree:
+        for grid in tree.get_nodes_in_group("GridInstances"):
+            if grid is Grid:
+                grid.queue_redraw()
 
 var cells: Array = []
 var preview_cells: Array[Vector2i] = []

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -62,7 +62,7 @@ func _update_scale():
     var viewport_size := _previous_viewport_size
     var horiz := (viewport_size.x - GRID_MARGIN) / (Grid.COLS * 2)
     var vert := (viewport_size.y - GRID_VERTICAL_OFFSET * 2) / Grid.ROWS
-    var new_size := floor(min(horiz, vert))
+    var new_size: int = int(floor(min(horiz, vert)))
     if new_size <= 0:
         new_size = 1
     Grid.set_cell_size(new_size)


### PR DESCRIPTION
## Summary
- resolve parse errors when resizing cards and grids
- keep variable typing consistent for `new_size`

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a92096ec832e8935334fb9ead453