### PR TITLE
Fix grid scaling by setting stretch settings

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -6,3 +6,9 @@ config_version=5
 [application]
 config/name="Squirrel Card Game"
 run/main_scene="res://scenes/Main.tscn"
+
+[display]
+window/size/viewport_width=1280
+window/size/viewport_height=720
+window/stretch/mode="canvas_items"
+window/stretch/aspect="expand"


### PR DESCRIPTION
## Summary
- configure display stretch settings so viewport resizes with the window

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844aade5f4c832e9bb46d86cb5c5424