### PR TITLE
Prevent card position changes while dragging

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -42,6 +42,8 @@ func _update_card_positions():
     var spacing := viewport_size.x / (num_cards + 1)
     for i in range(num_cards):
         var card := _cards[i]
+        if card.is_dragging:
+            continue
         var bottom_y: float = viewport_size.y - card.size.y / 2.0 - BOTTOM_MARGIN
         card.position = Vector2(spacing * (i + 1), bottom_y)
         card.set_original_position()


### PR DESCRIPTION
## Summary
- skip repositioning cards that are being dragged when the viewport resizes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6844ae226714832ea170f9b25a5426bd