### PR TITLE
Fix parse error in Main.gd

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -67,8 +67,7 @@ func _update_scale():
     var viewport_size := _previous_viewport_size
     var horiz := (viewport_size.x - GRID_MARGIN) / (Grid.COLS * 2)
     var base_ratio := Card.BASE_CARD_HEIGHT / Card.BASE_BLOCK_SIZE
-    var vert := (viewport_size.y - GRID_VERTICAL_OFFSET * 2 - BOTTOM_MARGIN) /
-            (Grid.ROWS * GRID_VERTICAL_SCALE + base_ratio)
+    var vert := (viewport_size.y - GRID_VERTICAL_OFFSET * 2 - BOTTOM_MARGIN) / (Grid.ROWS * GRID_VERTICAL_SCALE + base_ratio)
     var new_size: int = int(floor(min(horiz, vert)))
     if new_size <= 0:
         new_size = 1


### PR DESCRIPTION
## Summary
- fix multiline expression in `_update_scale` that caused a parse error in Godot

## Testing
- `godot` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bbec5af8832e97bb005b8071c53f