### PR TITLE
Fix tetris piece placement

### DIFF
--- a/scripts/Grid.gd
+++ b/scripts/Grid.gd
@@ -29,17 +29,25 @@ func _get_piece_indices(card) -> Array[Vector2i]:
     var positions: Array[Vector2] = card.get_global_block_positions()
     if positions.is_empty():
         return result
+
+    # Use the first block as the alignment reference. The piece must be
+    # reasonably close to the grid so that all blocks share the same offset.
     var first_local := to_local(positions[0])
-    var frac_x := fposmod(first_local.x, CELL_SIZE)
-    var frac_y := fposmod(first_local.y, CELL_SIZE)
+    var cell_x := first_local.x / CELL_SIZE
+    var cell_y := first_local.y / CELL_SIZE
+    var off_x := cell_x - round(cell_x)
+    var off_y := cell_y - round(cell_y)
+    if abs(off_x) > 0.25 or abs(off_y) > 0.25:
+        return result
+
     for pos in positions:
         var local := to_local(pos)
-        if abs(fposmod(local.x, CELL_SIZE) - frac_x) > 0.1:
+        var lx := local.x / CELL_SIZE - off_x
+        var ly := local.y / CELL_SIZE - off_y
+        if abs(lx - round(lx)) > 0.25 or abs(ly - round(ly)) > 0.25:
             return []
-        if abs(fposmod(local.y, CELL_SIZE) - frac_y) > 0.1:
-            return []
-        var ix := int(round(local.x / CELL_SIZE))
-        var iy := int(round(local.y / CELL_SIZE))
+        var ix := int(round(lx))
+        var iy := int(round(ly))
         result.append(Vector2i(ix, iy))
     return result
 


### PR DESCRIPTION
## Summary
- improve grid placement tolerance so tetrominoes can be dropped again

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844c31e220c832ea57f94595e159593