### PR TITLE
Add energy system and display

### DIFF
--- a/scenes/Card.tscn
+++ b/scenes/Card.tscn
@@ -6,3 +6,5 @@
 groups=["Cards"]
 
 script = ExtResource("1")
+
+[node name="CostLabel" type="Label" parent="."]

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -20,3 +20,5 @@ groups=["GridInstances"]
 script = ExtResource("2")
 
 [node name="EndTurnButton" type="Button" parent="."]
+
+[node name="EnergyLabel" type="Label" parent="."]

--- a/scripts/Card.gd
+++ b/scripts/Card.gd
@@ -4,10 +4,14 @@ class_name Card
 var card_name: String = ""
 var value: int = 1
 
+# Amount of energy required to play this card
+const energy_cost: int = 1
+
 # Name of the tetris shape for this card
 var shape_name: String = "L"
 
 var sprite: Sprite2D
+var cost_label: Label
 
 # Base sizes used prior to scaling
 const BASE_CARD_WIDTH := 100
@@ -56,6 +60,12 @@ func _ready():
     original_position = position
     sprite = Sprite2D.new()
     add_child(sprite)
+    cost_label = get_node_or_null("CostLabel")
+    if cost_label == null:
+        cost_label = Label.new()
+        add_child(cost_label)
+    cost_label.text = str(energy_cost)
+    cost_label.z_index = 1
     _update_textures()
     sprite.texture = card_texture
     sprite.centered = true
@@ -102,6 +112,8 @@ func _update_textures():
     card_texture = _create_card_texture(blocks)
     piece_texture = _create_piece_texture(blocks)
     size = Vector2(card_width, card_height)
+    if cost_label:
+        cost_label.position = Vector2(-size.x / 2 + 5, -size.y / 2 + 5)
 
 func _create_card_texture(blocks: Array[Vector2]) -> ImageTexture:
     var width := card_width

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -4,6 +4,9 @@ var _cards: Array[Card] = []
 var _previous_viewport_size := Vector2.ZERO
 var _grids: Array[Grid] = []
 var _end_button: Button
+var _energy_label: Label
+const ENERGY_PER_TURN := 3
+var _energy_available: int = ENERGY_PER_TURN
 
 const SHAPES := ["I", "L", "O", "T", "S", "Z"]
 const CARD_SCENE := preload("res://scenes/Card.tscn")
@@ -25,6 +28,11 @@ func _ready():
         _end_button.custom_minimum_size = Vector2(100, 30)
         _end_button.position = Vector2(10, 10)
         _end_button.pressed.connect(_on_EndTurnButton_pressed)
+
+    _energy_label = Label.new()
+    _energy_label.position = Vector2(120, 10)
+    add_child(_energy_label)
+    _update_energy_label()
 
     _add_random_cards()
 
@@ -76,10 +84,14 @@ func _update_scale():
     Card.update_scale(new_size)
 
 func on_card_dropped(card: Card) -> bool:
+    if _energy_available < card.energy_cost:
+        return false
     for grid in _grids:
         if grid.try_place_piece(card):
             _cards.erase(card)
             card.queue_free()
+            _energy_available -= card.energy_cost
+            _update_energy_label()
             _update_card_positions()
             clear_previews()
             return true
@@ -112,4 +124,10 @@ func _on_EndTurnButton_pressed() -> void:
     _add_random_cards()
     _update_card_positions()
     clear_previews()
+    _energy_available = ENERGY_PER_TURN
+    _update_energy_label()
+
+func _update_energy_label() -> void:
+    if _energy_label:
+        _energy_label.text = "Energy: %d/%d" % [_energy_available, ENERGY_PER_TURN]
 


### PR DESCRIPTION
## Summary
- show energy cost on each card using a `Label`
- add per-turn energy system with 3 energy
- reset energy on end turn
- display available energy in the main scene

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ca180170832ea671721a4bb686c7