### PR TITLE
Resolve Godot parse error due to typed array

### DIFF
--- a/scripts/Grid.gd
+++ b/scripts/Grid.gd
@@ -22,7 +22,7 @@ static func set_cell_size(new_size: float) -> void:
             if grid is Grid:
                 grid.queue_redraw()
 
-var cells: Array[Array[bool]] = []
+var cells: Array = []
 var preview_cells: Array[Vector2i] = []
 
 func _get_piece_indices(card: Node) -> Array[Vector2i]:


### PR DESCRIPTION
## Summary
- fix nested typed array declaration in `Grid.gd`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844dffd18e0832ea2986a46a91e8bee