### PR TITLE
Add hazard squares mechanic

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This repository contains a minimal Godot project for a simple 2D card game proto
 1. Open the folder in Godot 4.x.
 2. Run the project to see the empty scene. The left grid represents the enemy
    and the right grid is the player. Each side now displays a health counter
-   above its grid.
+   above its grid. At the start of each turn, four random squares on the
+   player's grid light up. Any lit square left uncovered when the "End Turn"
+   button is pressed causes one point of damage to the player.
 
 The project is intentionally minimal and can be extended with gameplay and assets.

--- a/scripts/Grid.gd
+++ b/scripts/Grid.gd
@@ -24,6 +24,7 @@ static func set_cell_size(new_size: float) -> void:
 
 var cells: Array = []
 var preview_cells: Array[Vector2i] = []
+var danger_cells: Array[Vector2i] = []
 
 func _get_piece_indices(card: Node) -> Array[Vector2i]:
     var result: Array[Vector2i] = []
@@ -77,6 +78,9 @@ func _draw() -> void:
     var preview_color := Color(0, 0, 1, 0.5)
     for idx in preview_cells:
         draw_rect(Rect2(idx.x * CELL_SIZE, idx.y * CELL_SIZE, CELL_SIZE, CELL_SIZE), preview_color)
+    var danger_color := Color(1, 0, 0, 0.5)
+    for idx in danger_cells:
+        draw_rect(Rect2(idx.x * CELL_SIZE, idx.y * CELL_SIZE, CELL_SIZE, CELL_SIZE), danger_color)
 
 func try_place_piece(card: Node) -> bool:
     var indices := _get_piece_indices(card)
@@ -113,3 +117,29 @@ func clear_preview() -> void:
         return
     preview_cells.clear()
     queue_redraw()
+
+func highlight_random_cells(num: int) -> void:
+    danger_cells.clear()
+    var chosen: Array[Vector2i] = []
+    var total := COLS * ROWS
+    num = clamp(num, 0, total)
+    while danger_cells.size() < num:
+        var x := randi_range(0, COLS - 1)
+        var y := randi_range(0, ROWS - 1)
+        var c := Vector2i(x, y)
+        if not danger_cells.has(c):
+            danger_cells.append(c)
+    queue_redraw()
+
+func clear_highlights() -> void:
+    if danger_cells.is_empty():
+        return
+    danger_cells.clear()
+    queue_redraw()
+
+func count_uncovered_highlights() -> int:
+    var count := 0
+    for c in danger_cells:
+        if not cells[c.x][c.y]:
+            count += 1
+    return count

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -12,6 +12,7 @@ var _energy_available: int = ENERGY_PER_TURN
 const STARTING_HEALTH := 10
 var _player_health: int = STARTING_HEALTH
 var _enemy_health: int = STARTING_HEALTH
+const HAZARDS_PER_ROUND := 4
 
 const SHAPES := ["I", "L", "O", "T", "S", "Z"]
 const CARD_SCENE := preload("res://scenes/Card.tscn")
@@ -50,6 +51,7 @@ func _ready() -> void:
     _update_scale()
     _update_card_positions()
     _position_grids()
+    _highlight_new_round()
 
 func _process(delta: float) -> void:
     var current_size := get_viewport_rect().size
@@ -118,6 +120,19 @@ func clear_previews() -> void:
     for grid in _grids:
         grid.clear_preview()
 
+func _highlight_new_round() -> void:
+    if _grids.size() < 2:
+        return
+    _grids[1].highlight_random_cells(HAZARDS_PER_ROUND)
+
+func _apply_danger_damage() -> void:
+    if _grids.size() < 2:
+        return
+    var dmg := _grids[1].count_uncovered_highlights()
+    _player_health -= dmg
+    _update_health_labels()
+    _grids[1].clear_highlights()
+
 func _discard_remaining_cards() -> void:
     for card in _cards:
         card.queue_free()
@@ -132,12 +147,14 @@ func _add_random_cards(num: int = 5) -> void:
         _cards.append(card)
 
 func _on_EndTurnButton_pressed() -> void:
+    _apply_danger_damage()
     _discard_remaining_cards()
     _add_random_cards()
     _update_card_positions()
     clear_previews()
     _energy_available = ENERGY_PER_TURN
     _update_energy_label()
+    _highlight_new_round()
 
 func _update_energy_label() -> void:
     if _energy_label:


### PR DESCRIPTION
## Summary
- implement random hazard squares on the player grid
- apply damage for uncovered hazards at end of turn
- display new hazard rules in README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6844ed624a60832e8dde7f7cdbe98093