### PR TITLE
Fix self-damage when placing pieces

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This repository contains a minimal Godot project for a simple 2D card game proto
    and the right grid is the player. Each side now displays a health counter
    above its grid. At the start of each turn, four random squares on the
    player's grid light up. Any lit square left uncovered when the "End Turn"
-   button is pressed causes one point of damage to the player.
+   button is pressed causes one point of damage to the player. Placing pieces
+   on the player's grid does not reduce health directly; damage only comes from
+   these uncovered hazard squares.
 
 The project is intentionally minimal and can be extended with gameplay and assets.

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -180,7 +180,5 @@ func _apply_damage(grid_idx: int, card: Card) -> void:
     var dmg: int = blocks.size()
     if grid_idx == 0:
         _enemy_health -= dmg
-    else:
-        _player_health -= dmg
     _update_health_labels()
 


### PR DESCRIPTION
## Summary
- prevent player health loss when a piece is placed on the player's grid
- clarify README about how player damage is dealt

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844eef4bef8832e939edcba9fd4afda