### PR TITLE
Fix typed array mismatch

### DIFF
--- a/scripts/ShapeData.gd
+++ b/scripts/ShapeData.gd
@@ -21,9 +21,12 @@ static func get_shapes() -> Dictionary:
     _load_data()
     return _shapes
 
-static func get_shape_names() -> Array:
+static func get_shape_names() -> Array[String]:
     _load_data()
-    return _shapes.keys()
+    var names: Array[String] = []
+    for n in _shapes.keys():
+        names.append(String(n))
+    return names
 
 static func get_blocks(name: String) -> Array[Vector2]:
     _load_data()


### PR DESCRIPTION
## Summary
- return an Array[String] from ShapeData.get_shape_names

## Testing
- `godot` not installed, so no tests run

------
https://chatgpt.com/codex/tasks/task_e_6845a42e5a18832e81120a2d06a2b889