### PR TITLE
Fix type inference error in AttackData

### DIFF
--- a/scripts/AttackData.gd
+++ b/scripts/AttackData.gd
@@ -14,7 +14,7 @@ static func _load_data() -> void:
         var json_text := file.get_as_text()
         var data = JSON.parse_string(json_text)
         if typeof(data) == TYPE_DICTIONARY and data.has("attacks"):
-            var arr := data["attacks"]
+            var arr: Array = data["attacks"]
             if arr is Array:
                 for attack in arr:
                     if attack is Array:


### PR DESCRIPTION
## Summary
- fix parse error in `AttackData.gd` by giving `arr` an explicit `Array` type

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845aae40538832eb888d146440e0df5