### PR TITLE
Ensure sprites stay within grid

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -212,9 +212,10 @@ func _apply_damage(grid_idx: int, card: Card) -> void:
 
 
 func _update_character_scale() -> void:
+    var grid_width := Grid.COLS * Grid.CELL_SIZE
     var grid_height := Grid.ROWS * Grid.CELL_SIZE * GRID_VERTICAL_SCALE
-    var target := grid_height * 0.7
-    var factor := target / 64.0
+    var max_size := min(grid_width, grid_height) * 0.7
+    var factor := max_size / 64.0
     _alien_sprite.scale = Vector2(factor, factor)
     _mech_sprite.scale = Vector2(factor, factor)
 


### PR DESCRIPTION
## Summary
- prevent the alien and mech from overlapping the grid

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ba50b0fc832e8939ff310cf36627