### PR TITLE
Apply damage only for hazard cells over mech

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This repository contains a minimal Godot project for a simple 2D card game proto
    and the right grid is the player. Each side now displays a health counter
    above its grid. At the start of each turn, one of the predefined attacks from
    `data/attacks.json` is chosen and those four squares on the player's grid
-   light up. Any lit square left uncovered when the "End Turn" button is pressed
-   causes one point of damage to the player. Placing pieces on the player's grid
-   does not reduce health directly; damage only comes from these uncovered
-   hazard squares.
+  light up. Any highlighted square left uncovered when the "End Turn" button is
+  pressed only deals damage if that cell overlaps the mech sprite. Placing
+  pieces on the player's grid does not reduce health directly; damage only comes
+  from these uncovered hazard squares that touch the mech.
 
 The project is intentionally minimal and can be extended with gameplay and assets.

--- a/scripts/Grid.gd
+++ b/scripts/Grid.gd
@@ -150,3 +150,12 @@ func count_uncovered_highlights() -> int:
         if not cells[c.x][c.y]:
             count += 1
     return count
+
+func count_uncovered_highlights_in_rect(area: Rect2) -> int:
+    var count := 0
+    for c in danger_cells:
+        if not cells[c.x][c.y]:
+            var center := to_global(Vector2((c.x + 0.5) * CELL_SIZE, (c.y + 0.5) * CELL_SIZE))
+            if area.has_point(center):
+                count += 1
+    return count

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -155,7 +155,11 @@ func _highlight_new_round() -> void:
 func _apply_danger_damage() -> void:
     if _grids.size() < 2:
         return
-    var dmg := _grids[1].count_uncovered_highlights()
+    var rect := Rect2()
+    if _mech_sprite and _mech_sprite.texture:
+        var tex_size := _mech_sprite.texture.get_size() * _mech_sprite.scale
+        rect = Rect2(_mech_sprite.global_position - tex_size / 2.0, tex_size)
+    var dmg := _grids[1].count_uncovered_highlights_in_rect(rect)
     _player_health -= dmg
     _update_health_labels()
     _grids[1].clear_highlights()


### PR DESCRIPTION
## Summary
- update damage logic to check if attack cells overlap the mech sprite
- add helper on Grid to count uncovered hazards inside a rect
- document new behaviour in README

## Testing
- `godot --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6845be3c64a8832ebd630b3e3907ff3f