### PR TITLE
Adjust sprite scaling to fill grid

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -218,8 +218,8 @@ func _apply_damage(grid_idx: int, card: Card) -> void:
 func _update_character_scale() -> void:
     var grid_width: float = Grid.COLS * Grid.CELL_SIZE
     var grid_height: float = Grid.ROWS * Grid.CELL_SIZE * GRID_VERTICAL_SCALE
-    var max_size: float = min(grid_width, grid_height) * 0.7
-    var factor: float = max_size / 64.0
+    var target_size: float = min(grid_width, grid_height)
+    var factor: float = target_size / 64.0
     _alien_sprite.scale = Vector2(factor, factor)
     _mech_sprite.scale = Vector2(factor, factor)
 


### PR DESCRIPTION
## Summary
- scale mech and alien sprites so they match the grid size

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6845c11674b4832eb0dc0edff92ca6da