### PR TITLE
Fix parse error in Main.gd scaling

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -222,14 +222,14 @@ func _update_character_scale() -> void:
 
     if _alien_sprite and _alien_sprite.texture:
         var tex_size := _alien_sprite.texture.get_size()
-        var base := max(tex_size.x, tex_size.y)
-        var factor := target_size / base
+        var base: float = max(tex_size.x, tex_size.y)
+        var factor: float = target_size / base
         _alien_sprite.scale = Vector2(factor, factor)
 
     if _mech_sprite and _mech_sprite.texture:
         var tex_size := _mech_sprite.texture.get_size()
-        var base := max(tex_size.x, tex_size.y)
-        var factor := target_size / base
+        var base: float = max(tex_size.x, tex_size.y)
+        var factor: float = target_size / base
         _mech_sprite.scale = Vector2(factor, factor)
 
 func _update_creature_positions() -> void:


### PR DESCRIPTION
## Summary
- ensure Godot can infer types by explicitly typing `base` and `factor` variables in character scaling code

## Testing
- `godot --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6845c6094f80832eb59cff59fe5bebf9