### PR TITLE
Align mech and alien sprites with grid

### DIFF
--- a/scripts/CharacterData.gd
+++ b/scripts/CharacterData.gd
@@ -5,6 +5,8 @@ const CHARACTERS_FILE := "res://data/characters.json"
 
 static var _characters: Dictionary = {}
 static var _loaded := false
+static var _bounds: Dictionary = {}
+static var _offsets: Dictionary = {}
 
 static func _load_data() -> void:
     if _loaded:
@@ -73,3 +75,57 @@ static func get_texture(name: String) -> ImageTexture:
     if _characters.has(name):
         return _generate_texture(_characters[name])
     return ImageTexture.new()
+
+static func get_bounds(name: String) -> Vector2:
+    _load_data()
+    if _bounds.has(name):
+        return _bounds[name]
+    if not _characters.has(name):
+        return Vector2.ZERO
+    var desc: Dictionary = _characters[name]
+    var min_x := desc.get("size", 0)
+    var min_y := desc.get("size", 0)
+    var max_x := 0
+    var max_y := 0
+    var shapes: Array = desc.get("shapes", [])
+    if shapes is Array:
+        for s in shapes:
+            if s is Dictionary:
+                match String(s.get("type", "")):
+                    "rect":
+                        var p: Array = s.get("position", [0, 0])
+                        var sz: Array = s.get("size", [0, 0])
+                        var x0: float = float(p[0])
+                        var y0: float = float(p[1])
+                        var x1: float = x0 + float(sz[0])
+                        var y1: float = y0 + float(sz[1])
+                        min_x = min(min_x, x0)
+                        min_y = min(min_y, y0)
+                        max_x = max(max_x, x1)
+                        max_y = max(max_y, y1)
+                    "circle":
+                        var ctr: Array = s.get("center", [0, 0])
+                        var rad: float = float(s.get("radius", 0))
+                        var x0 := float(ctr[0]) - rad
+                        var y0 := float(ctr[1]) - rad
+                        var x1 := float(ctr[0]) + rad
+                        var y1 := float(ctr[1]) + rad
+                        min_x = min(min_x, x0)
+                        min_y = min(min_y, y0)
+                        max_x = max(max_x, x1)
+                        max_y = max(max_y, y1)
+    var size := Vector2(max_x - min_x, max_y - min_y)
+    _bounds[name] = size
+
+    var img_size: float = float(desc.get("size", 0))
+    var center := Vector2((min_x + max_x) / 2.0, (min_y + max_y) / 2.0)
+    var offset := Vector2(img_size / 2.0 - center.x, img_size / 2.0 - center.y)
+    _offsets[name] = offset
+    return size
+
+static func get_center_offset(name: String) -> Vector2:
+    _load_data()
+    if _offsets.has(name):
+        return _offsets[name]
+    get_bounds(name)
+    return _offsets.get(name, Vector2.ZERO)

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -218,18 +218,19 @@ func _apply_damage(grid_idx: int, card: Card) -> void:
 func _update_character_scale() -> void:
     var grid_width: float = Grid.COLS * Grid.CELL_SIZE
     var grid_height: float = Grid.ROWS * Grid.CELL_SIZE * GRID_VERTICAL_SCALE
-    var target_size: float = min(grid_width, grid_height)
 
     if _alien_sprite and _alien_sprite.texture:
-        var tex_size := _alien_sprite.texture.get_size()
-        var base: float = max(tex_size.x, tex_size.y)
-        var factor: float = target_size / base
+        var bounds: Vector2 = CHARACTER_DATA.get_bounds("alien")
+        var factor_x: float = bounds.x > 0 ? grid_width / bounds.x : 1.0
+        var factor_y: float = bounds.y > 0 ? grid_height / bounds.y : 1.0
+        var factor: float = min(factor_x, factor_y)
         _alien_sprite.scale = Vector2(factor, factor)
 
     if _mech_sprite and _mech_sprite.texture:
-        var tex_size := _mech_sprite.texture.get_size()
-        var base: float = max(tex_size.x, tex_size.y)
-        var factor: float = target_size / base
+        var bounds: Vector2 = CHARACTER_DATA.get_bounds("mech")
+        var factor_x: float = bounds.x > 0 ? grid_width / bounds.x : 1.0
+        var factor_y: float = bounds.y > 0 ? grid_height / bounds.y : 1.0
+        var factor: float = min(factor_x, factor_y)
         _mech_sprite.scale = Vector2(factor, factor)
 
 func _update_creature_positions() -> void:
@@ -237,6 +238,8 @@ func _update_creature_positions() -> void:
         return
     var grid_width := Grid.COLS * Grid.CELL_SIZE
     var grid_height := Grid.ROWS * Grid.CELL_SIZE * GRID_VERTICAL_SCALE
-    _alien_sprite.position = _grids[0].position + Vector2(grid_width / 2, grid_height / 2)
-    _mech_sprite.position = _grids[1].position + Vector2(grid_width / 2, grid_height / 2)
+    var alien_off: Vector2 = CHARACTER_DATA.get_center_offset("alien") * _alien_sprite.scale.x
+    var mech_off: Vector2 = CHARACTER_DATA.get_center_offset("mech") * _mech_sprite.scale.x
+    _alien_sprite.position = _grids[0].position + Vector2(grid_width / 2, grid_height / 2) + alien_off
+    _mech_sprite.position = _grids[1].position + Vector2(grid_width / 2, grid_height / 2) + mech_off
 


### PR DESCRIPTION
## Summary
- compute bounding box and center offset for character sprites
- scale characters based on their bounds rather than texture size
- adjust sprite positions using the computed center offsets

## Testing
- `git diff --check`


------
https://chatgpt.com/codex/tasks/task_e_6845c6a9cbfc832ebc371628bff71e70