### PR TITLE
Ensure characters scale with grid

### DIFF
--- a/scripts/CharacterData.gd
+++ b/scripts/CharacterData.gd
@@ -1,12 +1,25 @@
 extends Node
 class_name CharacterData
 
+# Provides scaled textures for the alien and mech sprites. Textures are
+# regenerated whenever the grid cell size changes so that each pixel in the
+# texture corresponds to a grid square.
+
 const CHARACTERS_FILE := "res://data/characters.json"
+const GRID := preload("res://scripts/Grid.gd")
+
+static var _last_cell_size: int = -1
 
 static var _characters: Dictionary = {}
 static var _loaded := false
 static var _bounds: Dictionary = {}
 static var _offsets: Dictionary = {}
+
+static func _check_cell_size() -> void:
+    if _last_cell_size != GRID.CELL_SIZE:
+        _bounds.clear()
+        _offsets.clear()
+        _last_cell_size = GRID.CELL_SIZE
 
 static func _load_data() -> void:
     if _loaded:
@@ -47,7 +60,9 @@ static func _draw_rect(img: Image, pos: Vector2i, size: Vector2i, color: Color) 
                 img.set_pixel(px, py, color)
 
 static func _generate_texture(desc: Dictionary) -> ImageTexture:
-    var size := int(desc.get("size", 64))
+    var base_size := float(desc.get("size", 64))
+    var size := int(GRID.CELL_SIZE * GRID.COLS)
+    var ratio := float(size) / base_size
     var img := Image.create(size, size, false, Image.FORMAT_RGBA8)
     var base_col := _to_color(desc.get("base_color", [0, 0, 0, 0]))
     img.fill(base_col)
@@ -59,32 +74,36 @@ static func _generate_texture(desc: Dictionary) -> ImageTexture:
                 match String(s.get("type", "")):
                     "circle":
                         var c_arr: Array = s.get("center", [size / 2, size / 2])
-                        var ctr := Vector2(float(c_arr[0]), float(c_arr[1]))
-                        var rad := int(s.get("radius", 0))
+                        var ctr := Vector2(float(c_arr[0]) * ratio, float(c_arr[1]) * ratio)
+                        var rad := int(float(s.get("radius", 0)) * ratio)
                         _draw_circle(img, ctr, rad, col)
                     "rect":
                         var p_arr: Array = s.get("position", [0, 0])
                         var sz_arr: Array = s.get("size", [1, 1])
-                        var pos := Vector2i(int(p_arr[0]), int(p_arr[1]))
-                        var sz := Vector2i(int(sz_arr[0]), int(sz_arr[1]))
+                        var pos := Vector2i(int(round(float(p_arr[0]) * ratio)), int(round(float(p_arr[1]) * ratio)))
+                        var sz := Vector2i(int(round(float(sz_arr[0]) * ratio)), int(round(float(sz_arr[1]) * ratio)))
                         _draw_rect(img, pos, sz, col)
     return ImageTexture.create_from_image(img)
 
 static func get_texture(name: String) -> ImageTexture:
     _load_data()
+    _check_cell_size()
     if _characters.has(name):
         return _generate_texture(_characters[name])
     return ImageTexture.new()
 
 static func get_bounds(name: String) -> Vector2:
     _load_data()
+    _check_cell_size()
     if _bounds.has(name):
         return _bounds[name]
     if not _characters.has(name):
         return Vector2.ZERO
     var desc: Dictionary = _characters[name]
-    var min_x := float(desc.get("size", 0))
-    var min_y := float(desc.get("size", 0))
+    var scale := float(GRID.CELL_SIZE * GRID.COLS) / float(desc.get("size", 1))
+    var size_px := float(GRID.CELL_SIZE * GRID.COLS)
+    var min_x := size_px
+    var min_y := size_px
     var max_x := 0
     var max_y := 0
     var shapes: Array = desc.get("shapes", [])
@@ -95,21 +114,21 @@ static func get_bounds(name: String) -> Vector2:
                     "rect":
                         var p: Array = s.get("position", [0, 0])
                         var sz: Array = s.get("size", [0, 0])
-                        var x0: float = float(p[0])
-                        var y0: float = float(p[1])
-                        var x1: float = x0 + float(sz[0])
-                        var y1: float = y0 + float(sz[1])
+                        var x0: float = float(p[0]) * scale
+                        var y0: float = float(p[1]) * scale
+                        var x1: float = x0 + float(sz[0]) * scale
+                        var y1: float = y0 + float(sz[1]) * scale
                         min_x = min(min_x, x0)
                         min_y = min(min_y, y0)
                         max_x = max(max_x, x1)
                         max_y = max(max_y, y1)
                     "circle":
                         var ctr: Array = s.get("center", [0, 0])
-                        var rad: float = float(s.get("radius", 0))
-                        var x0 := float(ctr[0]) - rad
-                        var y0 := float(ctr[1]) - rad
-                        var x1 := float(ctr[0]) + rad
-                        var y1 := float(ctr[1]) + rad
+                        var rad: float = float(s.get("radius", 0)) * scale
+                        var x0 := float(ctr[0]) * scale - rad
+                        var y0 := float(ctr[1]) * scale - rad
+                        var x1 := float(ctr[0]) * scale + rad
+                        var y1 := float(ctr[1]) * scale + rad
                         min_x = min(min_x, x0)
                         min_y = min(min_y, y0)
                         max_x = max(max_x, x1)
@@ -117,7 +136,7 @@ static func get_bounds(name: String) -> Vector2:
     var size := Vector2(max_x - min_x, max_y - min_y)
     _bounds[name] = size
 
-    var img_size: float = float(desc.get("size", 0))
+    var img_size: float = float(GRID.CELL_SIZE * GRID.COLS)
     var center := Vector2((min_x + max_x) / 2.0, (min_y + max_y) / 2.0)
     var offset := Vector2(img_size / 2.0 - center.x, img_size / 2.0 - center.y)
     _offsets[name] = offset
@@ -125,6 +144,7 @@ static func get_bounds(name: String) -> Vector2:
 
 static func get_center_offset(name: String) -> Vector2:
     _load_data()
+    _check_cell_size()
     if _offsets.has(name):
         return _offsets[name]
     get_bounds(name)

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -219,6 +219,8 @@ func _update_character_scale() -> void:
     var grid_width: float = Grid.COLS * Grid.CELL_SIZE
     var grid_height: float = Grid.ROWS * Grid.CELL_SIZE * GRID_VERTICAL_SCALE
 
+    if _alien_sprite:
+        _alien_sprite.texture = CHARACTER_DATA.get_texture("alien")
     if _alien_sprite and _alien_sprite.texture:
         var tex_size: Vector2 = _alien_sprite.texture.get_size()
         var factor_x: float = grid_width / tex_size.x if tex_size.x > 0 else 1.0
@@ -226,6 +228,8 @@ func _update_character_scale() -> void:
         var factor: float = min(factor_x, factor_y)
         _alien_sprite.scale = Vector2(factor, factor)
 
+    if _mech_sprite:
+        _mech_sprite.texture = CHARACTER_DATA.get_texture("mech")
     if _mech_sprite and _mech_sprite.texture:
         var tex_size: Vector2 = _mech_sprite.texture.get_size()
         var factor_x: float = grid_width / tex_size.x if tex_size.x > 0 else 1.0


### PR DESCRIPTION
## Summary
- scale the alien and mech textures according to the current grid cell size
- regenerate sprite textures whenever the grid resizes

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c9fe4668832eb0b3f3a43657b314