### PR TITLE
Align creature images with grid

### DIFF
--- a/scripts/CharacterData.gd
+++ b/scripts/CharacterData.gd
@@ -138,7 +138,10 @@ static func get_bounds(name: String) -> Vector2:
 
     var img_size: float = float(GRID.CELL_SIZE * GRID.COLS)
     var center := Vector2((min_x + max_x) / 2.0, (min_y + max_y) / 2.0)
-    var offset := Vector2(img_size / 2.0 - center.x, img_size / 2.0 - center.y)
+    var raw_offset := Vector2(img_size / 2.0 - center.x, img_size / 2.0 - center.y)
+    var cell := float(GRID.CELL_SIZE)
+    var offset := Vector2(round(raw_offset.x / cell) * cell,
+        round(raw_offset.y / cell) * cell)
     _offsets[name] = offset
     return size
 

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -244,6 +244,13 @@ func _update_creature_positions() -> void:
     var grid_height := Grid.ROWS * Grid.CELL_SIZE * GRID_VERTICAL_SCALE
     var alien_off: Vector2 = CHARACTER_DATA.get_center_offset("alien") * _alien_sprite.scale.x
     var mech_off: Vector2 = CHARACTER_DATA.get_center_offset("mech") * _mech_sprite.scale.x
-    _alien_sprite.position = _grids[0].position + Vector2(grid_width / 2, grid_height / 2) + alien_off
-    _mech_sprite.position = _grids[1].position + Vector2(grid_width / 2, grid_height / 2) + mech_off
+    var alien_pos := _grids[0].position + Vector2(grid_width / 2, grid_height / 2) + alien_off
+    var mech_pos := _grids[1].position + Vector2(grid_width / 2, grid_height / 2) + mech_off
+    var cell := float(Grid.CELL_SIZE)
+    alien_pos.x = round(alien_pos.x / cell) * cell
+    alien_pos.y = round(alien_pos.y / cell) * cell
+    mech_pos.x = round(mech_pos.x / cell) * cell
+    mech_pos.y = round(mech_pos.y / cell) * cell
+    _alien_sprite.position = alien_pos
+    _mech_sprite.position = mech_pos
 


### PR DESCRIPTION
## Summary
- align background character sprites to the nearest grid cell
- snap center offsets to the grid cell size

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ccd92394832ea486d5783fafec8c