### PR TITLE
Handle alien damage by overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ This repository contains a minimal Godot project for a simple 2D card game proto
    above its grid. At the start of each turn, one of the predefined attacks from
    `data/attacks.json` is chosen and those four squares on the player's grid
   light up. Any highlighted square left uncovered when the "End Turn" button is
-  pressed only deals damage if that cell overlaps the mech sprite. Placing
-  pieces on the player's grid does not reduce health directly; damage only comes
-  from these uncovered hazard squares that touch the mech.
+  pressed only deals damage if that cell overlaps the mech sprite. Likewise,
+  placing pieces on the enemy grid only harms the alien for each block that
+  overlaps the alien sprite. Placing pieces outside the alien causes no damage.
+  Damage from the player side only comes from these uncovered hazard squares
+  that touch the mech.
 
 The project is intentionally minimal and can be extended with gameplay and assets.

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -208,9 +208,15 @@ func _update_health_label_positions() -> void:
     _player_health_label.position = _grids[1].position + Vector2(grid_width / 2, -20)
 
 func _apply_damage(grid_idx: int, card: Card) -> void:
-    var blocks: Array[Vector2] = ShapeData.get_blocks(card.shape_name)
-    var dmg: int = blocks.size()
-    if grid_idx == 0:
+    var dmg: int = 0
+    if grid_idx == 0 and _alien_sprite and _alien_sprite.texture:
+        var sprite_size := _alien_sprite.texture.get_size() * _alien_sprite.scale
+        var sprite_rect := Rect2(_alien_sprite.global_position - sprite_size / 2.0, sprite_size)
+        var blocks: Array[Vector2] = card.get_global_block_positions()
+        for b in blocks:
+            var block_rect := Rect2(b, Vector2(Grid.CELL_SIZE, Grid.CELL_SIZE))
+            if sprite_rect.intersects(block_rect):
+                dmg += 1
         _enemy_health -= dmg
     _update_health_labels()
 


### PR DESCRIPTION
## Summary
- compute damage based on how many blocks of a dropped piece cover the alien sprite
- describe new alien damage rule in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845ced07c48832e814943539f0473e9