### PR TITLE
Fix variable type inference warnings in Main.gd

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -286,9 +286,9 @@ func _shapes_overlap_rect(shapes: Array, top_left: Vector2, ratio: float, scale:
     return false
 
 func _circle_intersects_rect(center: Vector2, radius: float, rect: Rect2) -> bool:
-    var closest_x := clamp(center.x, rect.position.x, rect.position.x + rect.size.x)
-    var closest_y := clamp(center.y, rect.position.y, rect.position.y + rect.size.y)
-    var dx := center.x - closest_x
-    var dy := center.y - closest_y
+    var closest_x: float = clamp(center.x, rect.position.x, rect.position.x + rect.size.x)
+    var closest_y: float = clamp(center.y, rect.position.y, rect.position.y + rect.size.y)
+    var dx: float = center.x - closest_x
+    var dy: float = center.y - closest_y
     return dx * dx + dy * dy <= radius * radius
 


### PR DESCRIPTION
## Summary
- fix strict typing errors in `_circle_intersects_rect`

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d15ae7e4832e8e277d0eb31240f5