### PR TITLE
Fix GDScript parse warnings

### DIFF
--- a/scripts/AttackData.gd
+++ b/scripts/AttackData.gd
@@ -3,7 +3,7 @@ class_name AttackData
 
 const ATTACKS_FILE := "res://data/attacks.json"
 
-static var _attacks: Array[Array[Vector2i]] = []
+static var _attacks: Array = []
 static var _loaded: bool = false
 
 static func _load_data() -> void:

--- a/scripts/Grid.gd
+++ b/scripts/Grid.gd
@@ -125,7 +125,7 @@ func highlight_random_cells(num: int) -> void:
         for y in range(ROWS):
             all_cells.append(Vector2i(x, y))
     all_cells.shuffle()
-    var max_cells := min(num, all_cells.size())
+    var max_cells: int = min(num, all_cells.size())
     for i in range(max_cells):
         danger_cells.append(all_cells[i])
     queue_redraw()

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -242,7 +242,7 @@ func _update_sprite(sprite: Sprite2D, name: String, width: float, height: float)
         var tex_size: Vector2 = sprite.texture.get_size()
         var factor_x := width / tex_size.x if tex_size.x > 0 else 1.0
         var factor_y := height / tex_size.y if tex_size.y > 0 else 1.0
-        var factor := min(factor_x, factor_y)
+        var factor: float = min(factor_x, factor_y)
         sprite.scale = Vector2(factor, factor)
 
 func _update_creature_positions() -> void:


### PR DESCRIPTION
## Summary
- adjust AttackData typed array to avoid nested generics
- specify explicit int and float types to silence warnings in Grid and Main

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68460ebb8f5c832ea8875a4a998ba6d4