### PR TITLE
Align background sprites with grid origin

### DIFF
--- a/scripts/CharacterData.gd
+++ b/scripts/CharacterData.gd
@@ -14,11 +14,13 @@ static var _characters: Dictionary = {}
 static var _loaded := false
 static var _bounds: Dictionary = {}
 static var _offsets: Dictionary = {}
+static var _top_left_offsets: Dictionary = {}
 
 static func _check_cell_size() -> void:
     if _last_cell_size != GRID.CELL_SIZE:
         _bounds.clear()
         _offsets.clear()
+        _top_left_offsets.clear()
         _last_cell_size = GRID.CELL_SIZE
 
 static func _load_data() -> void:
@@ -163,6 +165,40 @@ static func get_center_offset(name: String) -> Vector2:
         return _offsets[name]
     get_bounds(name)
     return _offsets.get(name, Vector2.ZERO)
+
+static func get_top_left_offset(name: String) -> Vector2:
+    _load_data()
+    _check_cell_size()
+    if _top_left_offsets.has(name):
+        return _top_left_offsets[name]
+    if not _characters.has(name):
+        return Vector2.ZERO
+    var desc: Dictionary = _characters[name]
+    var scale := float(GRID.CELL_SIZE * GRID.COLS) / float(desc.get("size", 1))
+    var min_x := INF
+    var min_y := INF
+    var shapes: Array = desc.get("shapes", [])
+    if shapes is Array:
+        for s in shapes:
+            if s is Dictionary:
+                match String(s.get("type", "")):
+                    "rect":
+                        var p: Array = s.get("position", [0, 0])
+                        min_x = min(min_x, float(p[0]) * scale)
+                        min_y = min(min_y, float(p[1]) * scale)
+                    "circle":
+                        var c: Array = s.get("center", [0, 0])
+                        var rad: float = float(s.get("radius", 0)) * scale
+                        min_x = min(min_x, float(c[0]) * scale - rad)
+                        min_y = min(min_y, float(c[1]) * scale - rad)
+    if min_x == INF:
+        min_x = 0
+    if min_y == INF:
+        min_y = 0
+    var cell := float(GRID.CELL_SIZE)
+    var offset := Vector2(round(-min_x / cell) * cell, round(-min_y / cell) * cell)
+    _top_left_offsets[name] = offset
+    return offset
 
 static func get_description(name: String) -> Dictionary:
     _load_data()

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -60,11 +60,13 @@ func _ready() -> void:
     _alien_sprite = Sprite2D.new()
     _alien_sprite.texture = CHARACTER_DATA.get_texture("alien")
     _alien_sprite.z_index = -1
+    _alien_sprite.centered = false
     add_child(_alien_sprite)
 
     _mech_sprite = Sprite2D.new()
     _mech_sprite.texture = CHARACTER_DATA.get_texture("mech")
     _mech_sprite.z_index = -1
+    _mech_sprite.centered = false
     add_child(_mech_sprite)
 
     _add_random_cards()
@@ -158,7 +160,7 @@ func _apply_danger_damage() -> void:
     var rect := Rect2()
     if _mech_sprite and _mech_sprite.texture:
         var tex_size := _mech_sprite.texture.get_size() * _mech_sprite.scale
-        rect = Rect2(_mech_sprite.global_position - tex_size / 2.0, tex_size)
+        rect = Rect2(_mech_sprite.global_position, tex_size)
     var dmg := _grids[0].count_uncovered_highlights_in_rect(rect)
     _player_health -= dmg
     _update_health_labels()
@@ -217,8 +219,7 @@ func _apply_damage(grid_idx: int, card: Card) -> void:
         var base_size: float = float(desc.get("size", 1))
         var ratio: float = float(Grid.CELL_SIZE * Grid.COLS) / base_size
         var scale_factor: float = _alien_sprite.scale.x
-        var sprite_size := _alien_sprite.texture.get_size() * _alien_sprite.scale
-        var sprite_top_left := _alien_sprite.global_position - sprite_size / 2.0
+        var sprite_top_left := _alien_sprite.global_position
         var blocks: Array[Vector2] = card.get_global_block_positions()
         for b in blocks:
             var block_rect := Rect2(b, Vector2(Grid.CELL_SIZE, Grid.CELL_SIZE))
@@ -248,12 +249,10 @@ func _update_sprite(sprite: Sprite2D, name: String, width: float, height: float)
 func _update_creature_positions() -> void:
     if _grids.size() < 2:
         return
-    var grid_width := Grid.COLS * Grid.CELL_SIZE
-    var grid_height := Grid.ROWS * Grid.CELL_SIZE * GRID_VERTICAL_SCALE
-    var alien_off: Vector2 = CHARACTER_DATA.get_center_offset("alien") * _alien_sprite.scale.x
-    var mech_off: Vector2 = CHARACTER_DATA.get_center_offset("mech") * _mech_sprite.scale.x
-    var alien_pos := _grids[1].position + Vector2(grid_width / 2, grid_height / 2) + alien_off
-    var mech_pos := _grids[0].position + Vector2(grid_width / 2, grid_height / 2) + mech_off
+    var alien_off: Vector2 = CHARACTER_DATA.get_top_left_offset("alien") * _alien_sprite.scale.x
+    var mech_off: Vector2 = CHARACTER_DATA.get_top_left_offset("mech") * _mech_sprite.scale.x
+    var alien_pos := _grids[1].position + alien_off
+    var mech_pos := _grids[0].position + mech_off
     var cell := float(Grid.CELL_SIZE)
     alien_pos.x = round(alien_pos.x / cell) * cell
     alien_pos.y = round(alien_pos.y / cell) * cell


### PR DESCRIPTION
## Summary
- ensure sprites and grid share the same reference point
- keep lookup table for sprite top-left offsets
- update damage and positioning logic for new reference point

## Testing
- `no tests`

------
https://chatgpt.com/codex/tasks/task_e_684617e81fd8832e8d698cf7963ef334