### PR TITLE
Shift background sprites

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -258,6 +258,9 @@ func _update_creature_positions() -> void:
     alien_pos.y = round(alien_pos.y / cell) * cell
     mech_pos.x = round(mech_pos.x / cell) * cell
     mech_pos.y = round(mech_pos.y / cell) * cell
+    var bg_offset := Vector2(cell, 6.0 * cell)
+    alien_pos += bg_offset
+    mech_pos += bg_offset
     _alien_sprite.position = alien_pos
     _mech_sprite.position = mech_pos
 


### PR DESCRIPTION
## Summary
- offset mech and alien sprites by one cell right and six cells down

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684619641228832e80a648909a5e143f