### PR TITLE
Fix type inference warning

### DIFF
--- a/scripts/CharacterData.gd
+++ b/scripts/CharacterData.gd
@@ -49,7 +49,7 @@ static func _to_color(arr: Array) -> Color:
     return Color(r, g, b, a)
 
 static func _get_outline_color(desc: Dictionary) -> Color:
-    var arr := desc.get("outline_color")
+    var arr = desc.get("outline_color")
     if arr is Array:
         return _to_color(arr)
     return DEFAULT_OUTLINE_COLOR


### PR DESCRIPTION
## Summary
- fix GDScript warning about inferring Variant type in `CharacterData.gd`

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474d52a4b4832e8b296afdb8ef6151