### PR TITLE
Fix group lookup method name conflict

### DIFF
--- a/scripts/CharacterData.gd
+++ b/scripts/CharacterData.gd
@@ -313,7 +313,7 @@ static func get_description(name: String) -> Dictionary:
 # Returns a dictionary mapping group names to arrays of shape dictionaries for
 # the given character. If the shapes are not organized by group, the returned
 # dictionary contains a single entry with an empty string as the key.
-static func get_groups(name: String) -> Dictionary:
+static func get_shape_groups(name: String) -> Dictionary:
     _load_data()
     if not _characters.has(name):
         return {}

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -311,7 +311,7 @@ func _point_in_shape(point: Vector2, shape: Dictionary, top_left: Vector2, ratio
 func _group_at_point(name: String, desc: Dictionary, sprite: Sprite2D, point: Vector2) -> String:
     if desc.is_empty() or sprite.texture == null:
         return ""
-    var groups = CHARACTER_DATA.get_groups(name)
+    var groups = CHARACTER_DATA.get_shape_groups(name)
     if groups.is_empty():
         if desc.has("shapes"):
             groups = {"": desc["shapes"]}


### PR DESCRIPTION
## Summary
- rename CharacterData.get_groups to `get_shape_groups`
- update call site in Main.gd

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475dd9fe94832e839f7ed7b3eaf1cc