### PR TITLE
Fix grid index type inference

### DIFF
--- a/scripts/CharacterData.gd
+++ b/scripts/CharacterData.gd
@@ -321,7 +321,7 @@ static func get_grid_index(name: String) -> int:
     _load_data()
     if not _characters.has(name):
         return -1
-    var grid_val := _characters[name].get("grid", -1)
+    var grid_val = _characters[name].get("grid", -1)
     if typeof(grid_val) == TYPE_STRING:
         var lower := String(grid_val).to_lower()
         if lower == "left":


### PR DESCRIPTION
## Summary
- remove typed inference from `grid_val` to avoid GDScript error

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68476b749d38832e9381dddcca2b3d28