### PR TITLE
Fix variable inference warnings in Main.gd

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -274,10 +274,10 @@ func _update_creature_positions() -> void:
     for g in _grids:
         centers.append(g.position + Vector2(grid_width / 2.0, grid_height / 2.0))
     if _mech_sprite:
-        var idx := clamp(_mech_grid_idx, 0, _grids.size() - 1)
+        var idx: int = clamp(_mech_grid_idx, 0, _grids.size() - 1)
         _mech_sprite.position = centers[idx]
     if _alien_sprite:
-        var idx := clamp(_alien_grid_idx, 0, _grids.size() - 1)
+        var idx: int = clamp(_alien_grid_idx, 0, _grids.size() - 1)
         _alien_sprite.position = centers[idx]
 
 func _shapes_overlap_rect(shapes: Array, top_left: Vector2, ratio: float, scale: Vector2, rect: Rect2) -> bool:


### PR DESCRIPTION
## Summary
- avoid typed inference from `Variant` by explicitly typing `idx`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68476c15044c832ebef63096c720b54c