### PR TITLE
Anchor sprites at top-left

### DIFF
--- a/scripts/CharacterData.gd
+++ b/scripts/CharacterData.gd
@@ -168,8 +168,12 @@ static func _generate_texture(desc: Dictionary) -> ImageTexture:
                         min_x = min(min_x, cx)
                         min_y = min(min_y, cy)
 
-    var offset_x: float = -float(min(0.0, min_x))
-    var offset_y: float = -float(min(0.0, min_y))
+    # Always translate shapes so the minimum coordinates line up with (0, 0).
+    # This means the top-left corner of the final texture corresponds to
+    # the smallest x and y values found in the description regardless of
+    # whether they are positive or negative.
+    var offset_x: float = -float(min_x)
+    var offset_y: float = -float(min_y)
 
     var img := Image.create(size, size, false, Image.FORMAT_RGBA8)
     var base_col := _to_color(desc.get("base_color", [0, 0, 0, 0]))
@@ -250,8 +254,10 @@ static func get_bounds(name: String) -> Vector2:
     if min_y == INF:
         min_y = 0
 
-    var translation_x: float = -float(min(0.0, min_x))
-    var translation_y: float = -float(min(0.0, min_y))
+    # Offset so the minimum coordinates align with the origin. This keeps the
+    # sprite anchored with its top-left corner at (0, 0).
+    var translation_x: float = -float(min_x)
+    var translation_y: float = -float(min_y)
 
     var size := Vector2(max_x - min_x, max_y - min_y)
     _bounds[name] = size
@@ -302,8 +308,9 @@ static func get_top_left_offset(name: String) -> Vector2:
         min_x = 0
     if min_y == INF:
         min_y = 0
-    var translation_x: float = -float(min(0.0, min_x))
-    var translation_y: float = -float(min(0.0, min_y))
+    # Use the minimum coordinates to anchor the top-left corner at (0, 0).
+    var translation_x: float = -float(min_x)
+    var translation_y: float = -float(min_y)
     var cell := float(GRID.CELL_SIZE)
     var offset := Vector2(round(translation_x / cell) * cell, round(translation_y / cell) * cell)
     _top_left_offsets[name] = offset


### PR DESCRIPTION
## Summary
- keep generated textures anchored to the minimum coordinates
- adjust bounds and offsets calculations for the new origin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68476f159c88832ea83a55abe20b4712