### PR TITLE
Support single shape dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ This repository contains a minimal Godot project for a simple 2D card game proto
 - `data/shapes.json` – Available piece shapes and their energy costs.
 - `data/attacks.json` – Predefined 4-cell attack patterns used each turn.
  - `data/characters.json` – Simple pixel art descriptions for the alien and mech.
-   Shapes may be grouped under named keys (for example `"left_arm"`) inside the
-   `shapes` dictionary. Each entry can optionally include an `outline_color`
-   array used when drawing the sprite. Shape positions are specified relative to
-   the top-left corner of the sprite canvas and negative values are no longer
-   supported.
+  Shapes may be grouped under named keys (for example `"left_arm"`) inside the
+  `shapes` dictionary. Each entry may contain an array of shapes or a single
+  shape dictionary. Each entry can optionally include an `outline_color` array
+  used when drawing the sprite. Shape positions are specified relative to the
+  top-left corner of the sprite canvas and negative values are no longer
+  supported.
 
 ## Getting Started
 1. Open the folder in Godot 4.x.

--- a/scripts/CharacterData.gd
+++ b/scripts/CharacterData.gd
@@ -127,11 +127,17 @@ static func _extract_all_shapes(data: Variant) -> Array:
             if s is Dictionary:
                 result.append(s)
     elif data is Dictionary:
-        for v in data.values():
-            if v is Array:
-                for s in v:
-                    if s is Dictionary:
-                        result.append(s)
+        # Support either an array of shapes or a single shape dictionary
+        if data.has("type"):
+            result.append(data)
+        else:
+            for v in data.values():
+                if v is Array:
+                    for s in v:
+                        if s is Dictionary:
+                            result.append(s)
+                elif v is Dictionary and v.has("type"):
+                    result.append(v)
     return result
 
 static func _generate_texture(desc: Dictionary) -> ImageTexture:


### PR DESCRIPTION
## Summary
- allow `CharacterData` to extract shapes when entries are single dictionaries instead of arrays
- document the accepted formats for `shapes` in the README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6847780f7728832ea7e831b8cb94ab27