### PR TITLE
Switch characters to grid coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This repository contains a minimal Godot project for a simple 2D card game proto
   Shapes may be grouped under named keys (for example `"left_arm"`) inside the
   `shapes` dictionary. Each entry may contain an array of shapes or a single
   shape dictionary. Each entry can optionally include an `outline_color` array
-  used when drawing the sprite. Shape positions are specified relative to the
-  top-left corner of the sprite canvas and negative values are no longer
-  supported.
+  used when drawing the sprite. Shape positions are specified using grid
+  coordinates measured from the top-left corner of the sprite canvas and
+  negative values are no longer supported.
 
 ## Getting Started
 1. Open the folder in Godot 4.x.

--- a/data/characters.json
+++ b/data/characters.json
@@ -1,14 +1,14 @@
 {
   "header": {
-    "instructions": "Add new characters as top-level keys. Each character entry contains a size, optional grid index, colors, and a 'shapes' dictionary. Shape positions are measured from the top-left corner of a 50x50 canvas. Example shapes show how to place a square in the top-left and bottom-right corners:",
+    "instructions": "Add new characters as top-level keys. Each character entry contains an optional grid index, colors, and a 'shapes' dictionary. Shape positions are measured in grid coordinates (columns and rows). Example shapes show how to place a square in the top-left and bottom-right cells:",
     "examples": {
-      "square_top_left": {"type": "rect", "position": [0, 0], "size": [5, 5], "color": [1, 1, 1, 1]},
-      "square_bottom_right": {"type": "rect", "position": [45, 45], "size": [5, 5], "color": [1, 1, 1, 1]}
+      "square_top_left": {"type": "rect", "position": [0, 0], "size": [1, 1], "color": [1, 1, 1, 1]},
+      "square_bottom_right": {"type": "rect", "position": [9, 19], "size": [1, 1], "color": [1, 1, 1, 1]}
     }
   },
   "alien": {
-	"size": 50,
-	"grid": "right",
+        "size": 10,
+        "grid": "right",
 	"base_color": [
 	  0,
 	  0,
@@ -26,12 +26,12 @@
                 {
                   "type": "rect",
                   "position": [
-                        45,
-                        45
+                        9,
+                        19
                   ],
                   "size": [
-                        5,
-                        5
+                        1,
+                        1
                   ],
                   "color": [
                         1,
@@ -44,8 +44,8 @@
         }
   },
   "mech": {
-	"size": 50,
-	"grid": "left",
+        "size": 10,
+        "grid": "left",
 	"base_color": [
 	  0,
 	  0,
@@ -63,12 +63,12 @@
                 {
                   "type": "rect",
                   "position": [
-                        45,
-                        45
+                        9,
+                        19
                   ],
                   "size": [
-                        5,
-                        5
+                        1,
+                        1
                   ],
                   "color": [
                         0,

--- a/scripts/CharacterData.gd
+++ b/scripts/CharacterData.gd
@@ -141,15 +141,13 @@ static func _extract_all_shapes(data: Variant) -> Array:
     return result
 
 static func _generate_texture(desc: Dictionary) -> ImageTexture:
-    var base_size := float(desc.get("size", 64))
-    var size := int(GRID.CELL_SIZE * GRID.COLS)
-    var ratio := float(size) / base_size
+    var width := int(GRID.CELL_SIZE * GRID.COLS)
+    var height := int(GRID.CELL_SIZE * GRID.ROWS)
+    var cell := float(GRID.CELL_SIZE)
 
     var shapes: Array = _extract_all_shapes(desc.get("shapes", []))
-    var offset_x: float = 0.0
-    var offset_y: float = 0.0
 
-    var img := Image.create(size, size, false, Image.FORMAT_RGBA8)
+    var img := Image.create(width, height, false, Image.FORMAT_RGBA8)
     var base_col := _to_color(desc.get("base_color", [0, 0, 0, 0]))
     var outline_col := _get_outline_color(desc)
     img.fill(base_col)
@@ -157,16 +155,16 @@ static func _generate_texture(desc: Dictionary) -> ImageTexture:
         var col := _to_color(s.get("color", [1, 1, 1, 1]))
         match String(s.get("type", "")):
             "circle":
-                var c_arr: Array = s.get("center", [size / 2, size / 2])
-                var ctr := Vector2((float(c_arr[0]) + offset_x) * ratio, (float(c_arr[1]) + offset_y) * ratio)
-                var rad := int(float(s.get("radius", 0)) * ratio)
+                var c_arr: Array = s.get("center", [0, 0])
+                var ctr := Vector2(float(c_arr[0]) * cell, float(c_arr[1]) * cell)
+                var rad := int(float(s.get("radius", 0)) * cell)
                 _draw_circle(img, ctr, rad, col)
                 _draw_circle_outline(img, ctr, rad, outline_col)
             "rect":
                 var p_arr: Array = s.get("position", [0, 0])
                 var sz_arr: Array = s.get("size", [1, 1])
-                var pos := Vector2i(int(round((float(p_arr[0]) + offset_x) * ratio)), int(round((float(p_arr[1]) + offset_y) * ratio)))
-                var sz := Vector2i(int(round(float(sz_arr[0]) * ratio)), int(round(float(sz_arr[1]) * ratio)))
+                var pos := Vector2i(int(round(float(p_arr[0]) * cell)), int(round(float(p_arr[1]) * cell)))
+                var sz := Vector2i(int(round(float(sz_arr[0]) * cell)), int(round(float(sz_arr[1]) * cell)))
                 _draw_rect(img, pos, sz, col)
                 _draw_rect_outline(img, pos, sz, outline_col)
     return ImageTexture.create_from_image(img)
@@ -186,7 +184,7 @@ static func get_bounds(name: String) -> Vector2:
     if not _characters.has(name):
         return Vector2.ZERO
     var desc: Dictionary = _characters[name]
-    var scale := float(GRID.CELL_SIZE * GRID.COLS) / float(desc.get("size", 1))
+    var scale := float(GRID.CELL_SIZE)
     var size_px := float(GRID.CELL_SIZE * GRID.COLS)
     var max_x := 0.0
     var max_y := 0.0
@@ -212,9 +210,10 @@ static func get_bounds(name: String) -> Vector2:
     var size := Vector2(max_x, max_y)
     _bounds[name] = size
 
-    var img_size: float = float(GRID.CELL_SIZE * GRID.COLS)
+    var img_w: float = float(GRID.CELL_SIZE * GRID.COLS)
+    var img_h: float = float(GRID.CELL_SIZE * GRID.ROWS)
     var center := Vector2(max_x / 2.0, max_y / 2.0)
-    var raw_offset := Vector2(img_size / 2.0 - center.x, img_size / 2.0 - center.y)
+    var raw_offset := Vector2(img_w / 2.0 - center.x, img_h / 2.0 - center.y)
     var cell := float(GRID.CELL_SIZE)
     var offset := Vector2(round(raw_offset.x / cell) * cell,
         round(raw_offset.y / cell) * cell)
@@ -238,7 +237,7 @@ static func get_top_left_offset(name: String) -> Vector2:
         _top_left_offsets[name] = Vector2.ZERO
         return Vector2.ZERO
     var desc: Dictionary = _characters[name]
-    var scale := float(GRID.CELL_SIZE * GRID.COLS) / float(desc.get("size", 1))
+    var scale := float(GRID.CELL_SIZE)
     var min_x := 0.0
     var min_y := 0.0
     var shapes: Array = _extract_all_shapes(desc.get("shapes", []))

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -233,8 +233,7 @@ func _apply_damage(grid_idx: int, card: Card) -> void:
     if grid_idx == _alien_grid_idx and _alien_sprite and _alien_sprite.texture:
         var desc: Dictionary = CHARACTER_DATA.get_description("alien")
         var shapes: Array = desc.get("shapes", [])
-        var base_size: float = float(desc.get("size", 1))
-        var ratio: float = float(Grid.CELL_SIZE * Grid.COLS) / base_size
+        var ratio: float = float(Grid.CELL_SIZE)
         var sprite_scale := Vector2(_alien_sprite.scale.x, _alien_sprite.scale.y)
         var tex_size: Vector2 = _alien_sprite.texture.get_size() * sprite_scale
         var sprite_top_left := _alien_sprite.global_position
@@ -261,10 +260,9 @@ func _update_sprite(sprite: Sprite2D, name: String, width: float, height: float)
     sprite.offset = CHARACTER_DATA.get_top_left_offset(name)
     if sprite.texture:
         var tex_size: Vector2 = sprite.texture.get_size()
-        var factor_x := width / tex_size.x if tex_size.x > 0 else 1.0
-        var factor_y := height / tex_size.y if tex_size.y > 0 else 1.0
-        var factor: float = min(factor_x, factor_y)
-        sprite.scale = Vector2(factor, factor * GRID_VERTICAL_SCALE)
+        var scale_x := width / tex_size.x if tex_size.x > 0 else 1.0
+        var scale_y := height / tex_size.y if tex_size.y > 0 else 1.0
+        sprite.scale = Vector2(scale_x, scale_y)
 
 func _update_creature_positions() -> void:
     if _grids.size() < 2:
@@ -331,8 +329,7 @@ func _group_at_point(name: String, desc: Dictionary, sprite: Sprite2D, point: Ve
             groups = {"": desc["shapes"]}
         else:
             return ""
-    var base_size: float = float(desc.get("size", 1))
-    var ratio: float = float(Grid.CELL_SIZE * Grid.COLS) / base_size
+    var ratio: float = float(Grid.CELL_SIZE)
     var scale := sprite.scale
     var tex_size := sprite.texture.get_size() * scale
     var top_left := sprite.global_position


### PR DESCRIPTION
## Summary
- define character sprite shapes using grid coordinates instead of 50×50 space
- update character texture generation and offset math for the new system
- scale sprites directly to grid dimensions
- document grid-based coordinates

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478833eaa0832ea3fed02d3b038e27