### PR TITLE
Increase grid width to 20 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,5 @@ This repository contains a minimal Godot project for a simple 2D card game proto
   that touch the mech.
 
 The project is intentionally minimal and can be extended with gameplay and assets.
+Each grid now spans 20 columns, so both the player and enemy grids adjust their
+cell size to fit side by side without overlapping.

--- a/data/characters.json
+++ b/data/characters.json
@@ -3,11 +3,11 @@
     "instructions": "Add new characters as top-level keys. Each character entry contains an optional grid index, colors, and a 'shapes' dictionary. Shape positions are measured in grid coordinates (columns and rows). Example shapes show how to place a square in the top-left and bottom-right cells:",
     "examples": {
       "square_top_left": {"type": "rect", "position": [0, 0], "size": [1, 1], "color": [1, 1, 1, 1]},
-      "square_bottom_right": {"type": "rect", "position": [9, 19], "size": [1, 1], "color": [1, 1, 1, 1]}
+      "square_bottom_right": {"type": "rect", "position": [19, 19], "size": [1, 1], "color": [1, 1, 1, 1]}
     }
   },
   "alien": {
-        "size": 10,
+        "size": 20,
         "grid": "right",
 	"base_color": [
 	  0,
@@ -26,7 +26,7 @@
                 {
                   "type": "rect",
                   "position": [
-                        9,
+                        19,
                         19
                   ],
                   "size": [
@@ -44,7 +44,7 @@
         }
   },
   "mech": {
-        "size": 10,
+        "size": 20,
         "grid": "left",
 	"base_color": [
 	  0,
@@ -63,7 +63,7 @@
                 {
                   "type": "rect",
                   "position": [
-                        9,
+                        19,
                         19
                   ],
                   "size": [

--- a/scripts/Grid.gd
+++ b/scripts/Grid.gd
@@ -1,7 +1,7 @@
 extends Node2D
 class_name Grid
 
-const COLS := 10
+const COLS := 20
 const ROWS := 20
 # Base cell size used to compute scaling
 const BASE_CELL_SIZE := 20


### PR DESCRIPTION
## Summary
- enlarge grid size to 20 columns
- adjust character data to keep example shapes at the bottom-right
- document new grid width in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684792291ce8832ebbfc83be089118be