### PR TITLE
Add health to character groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ This repository contains a minimal Godot project for a simple 2D card game proto
 - `data/attacks.json` – Predefined 4-cell attack patterns used each turn.
  - `data/characters.json` – Simple pixel art descriptions for the alien and mech.
   Shapes may be grouped under named keys (for example `"left_arm"`) inside the
-  `shapes` dictionary. Each entry may contain an array of shapes or a single
-  shape dictionary. Each entry can optionally include an `outline_color` array
-  used when drawing the sprite. Shape positions are specified using grid
-  coordinates measured from the top-left corner of the sprite canvas and
-  negative values are no longer supported.
+  `shapes` dictionary. Each group now stores a `health` value equal to the number
+  of grid squares covered by that group and a `shapes` array describing the
+  rectangles. Each entry can optionally include an `outline_color` array used
+  when drawing the sprite. Shape positions are specified using grid coordinates
+  measured from the top-left corner of the sprite canvas and negative values are
+  no longer supported.
 
 ## Getting Started
 1. Open the folder in Godot 4.x.

--- a/data/characters.json
+++ b/data/characters.json
@@ -1,545 +1,584 @@
 {
   "header": {
-	"instructions": "Add new characters as top-level keys. Each character entry contains an optional grid index, colors, and a 'shapes' dictionary. Shape positions are measured in grid coordinates (columns and rows). Example shapes show how to place a square in the top-left and bottom-right cells:",
-	"examples": {
-	  "square_top_left": {
-		"type": "rect",
-		"position": [
-		  0,
-		  0
-		],
-		"size": [
-		  1,
-		  1
-		],
-		"color": [
-		  1,
-		  1,
-		  1,
-		  1
-		]
-	  },
-	  "square_bottom_right": {
-		"type": "rect",
-		"position": [
-		  19,
-		  19
-		],
-		"size": [
-		  1,
-		  1
-		],
-		"color": [
-		  1,
-		  1,
-		  1,
-		  1
-		]
-	  }
-	}
+    "instructions": "Add new characters as top-level keys. Each character entry contains an optional grid index, colors, and a 'shapes' dictionary. Shape positions are measured in grid coordinates (columns and rows). Example shapes show how to place a square in the top-left and bottom-right cells:",
+    "examples": {
+      "square_top_left": {
+        "type": "rect",
+        "position": [
+          0,
+          0
+        ],
+        "size": [
+          1,
+          1
+        ],
+        "color": [
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "square_bottom_right": {
+        "type": "rect",
+        "position": [
+          19,
+          19
+        ],
+        "size": [
+          1,
+          1
+        ],
+        "color": [
+          1,
+          1,
+          1,
+          1
+        ]
+      }
+    }
   },
   "alien": {
-	"size": 20,
-	"grid": "right",
-	"base_color": [
-	  0,
-	  0,
-	  0,
-	  0
-	],
-	"outline_color": [
-	  0,
-	  0,
-	  0,
-	  1
-	],
-	"shapes": {
-	  "antennae": [
-		{
-		  "type": "rect",
-		  "position": [
-			9,
-			1
-		  ],
-		  "size": [
-			1,
-			1
-		  ],
-		  "color": [
-			0,
-			1,
-			0,
-			1
-		  ]
-		},
-		{
-		  "type": "rect",
-		  "position": [
-			11,
-			1
-		  ],
-		  "size": [
-			1,
-			1
-		  ],
-		  "color": [
-			0,
-			1,
-			0,
-			1
-		  ]
-		}
-	  ],
-	  "head": [
-		{
-		  "type": "rect",
-		  "position": [
-			8,
-			2
-		  ],
-		  "size": [
-			4,
-			2
-		  ],
-		  "color": [
-			0,
-			1,
-			0,
-			1
-		  ]
-		}
-	  ],
-	  "thorax": [
-		{
-		  "type": "rect",
-		  "position": [
-			7,
-			4
-		  ],
-		  "size": [
-			6,
-			3
-		  ],
-		  "color": [
-			0,
-			1,
-			0,
-			1
-		  ]
-		},
-		{
-		  "type": "rect",
-		  "position": [
-			8,
-			7
-		  ],
-		  "size": [
-			4,
-			2
-		  ],
-		  "color": [
-			0,
-			1,
-			0,
-			1
-		  ]
-		}
-	  ],
-	  "left_arms": [
-		{
-		  "type": "rect",
-		  "position": [
-			5,
-			4
-		  ],
-		  "size": [
-			1,
-			3
-		  ],
-		  "color": [
-			0,
-			1,
-			0,
-			1
-		  ]
-		},
-		{
-		  "type": "rect",
-		  "position": [
-			4,
-			7
-		  ],
-		  "size": [
-			1,
-			3
-		  ],
-		  "color": [
-			0,
-			1,
-			0,
-			1
-		  ]
-		}
-	  ],
-	  "right_arms": [
-		{
-		  "type": "rect",
-		  "position": [
-			13,
-			4
-		  ],
-		  "size": [
-			1,
-			3
-		  ],
-		  "color": [
-			0,
-			1,
-			0,
-			1
-		  ]
-		},
-		{
-		  "type": "rect",
-		  "position": [
-			14,
-			7
-		  ],
-		  "size": [
-			1,
-			3
-		  ],
-		  "color": [
-			0,
-			1,
-			0,
-			1
-		  ]
-		}
-	  ],
-	  "left_legs": [
-		{
-		  "type": "rect",
-		  "position": [
-			7,
-			9
-		  ],
-		  "size": [
-			2,
-			4
-		  ],
-		  "color": [
-			0,
-			1,
-			0,
-			1
-		  ]
-		},
-		{
-		  "type": "rect",
-		  "position": [
-			6,
-			13
-		  ],
-		  "size": [
-			2,
-			2
-		  ],
-		  "color": [
-			0,
-			1,
-			0,
-			1
-		  ]
-		}
-	  ],
-	  "right_legs": [
-		{
-		  "type": "rect",
-		  "position": [
-			11,
-			9
-		  ],
-		  "size": [
-			2,
-			4
-		  ],
-		  "color": [
-			0,
-			1,
-			0,
-			1
-		  ]
-		},
-		{
-		  "type": "rect",
-		  "position": [
-			12,
-			13
-		  ],
-		  "size": [
-			2,
-			2
-		  ],
-		  "color": [
-			0,
-			1,
-			0,
-			1
-		  ]
-		}
-	  ]
-	}
+    "size": 20,
+    "grid": "right",
+    "base_color": [
+      0,
+      0,
+      0,
+      0
+    ],
+    "outline_color": [
+      0,
+      0,
+      0,
+      1
+    ],
+    "shapes": {
+      "antennae": {
+        "health": 2,
+        "shapes": [
+          {
+            "type": "rect",
+            "position": [
+              9,
+              1
+            ],
+            "size": [
+              1,
+              1
+            ],
+            "color": [
+              0,
+              1,
+              0,
+              1
+            ]
+          },
+          {
+            "type": "rect",
+            "position": [
+              11,
+              1
+            ],
+            "size": [
+              1,
+              1
+            ],
+            "color": [
+              0,
+              1,
+              0,
+              1
+            ]
+          }
+        ]
+      },
+      "head": {
+        "health": 8,
+        "shapes": [
+          {
+            "type": "rect",
+            "position": [
+              8,
+              2
+            ],
+            "size": [
+              4,
+              2
+            ],
+            "color": [
+              0,
+              1,
+              0,
+              1
+            ]
+          }
+        ]
+      },
+      "thorax": {
+        "health": 26,
+        "shapes": [
+          {
+            "type": "rect",
+            "position": [
+              7,
+              4
+            ],
+            "size": [
+              6,
+              3
+            ],
+            "color": [
+              0,
+              1,
+              0,
+              1
+            ]
+          },
+          {
+            "type": "rect",
+            "position": [
+              8,
+              7
+            ],
+            "size": [
+              4,
+              2
+            ],
+            "color": [
+              0,
+              1,
+              0,
+              1
+            ]
+          }
+        ]
+      },
+      "left_arms": {
+        "health": 6,
+        "shapes": [
+          {
+            "type": "rect",
+            "position": [
+              5,
+              4
+            ],
+            "size": [
+              1,
+              3
+            ],
+            "color": [
+              0,
+              1,
+              0,
+              1
+            ]
+          },
+          {
+            "type": "rect",
+            "position": [
+              4,
+              7
+            ],
+            "size": [
+              1,
+              3
+            ],
+            "color": [
+              0,
+              1,
+              0,
+              1
+            ]
+          }
+        ]
+      },
+      "right_arms": {
+        "health": 6,
+        "shapes": [
+          {
+            "type": "rect",
+            "position": [
+              13,
+              4
+            ],
+            "size": [
+              1,
+              3
+            ],
+            "color": [
+              0,
+              1,
+              0,
+              1
+            ]
+          },
+          {
+            "type": "rect",
+            "position": [
+              14,
+              7
+            ],
+            "size": [
+              1,
+              3
+            ],
+            "color": [
+              0,
+              1,
+              0,
+              1
+            ]
+          }
+        ]
+      },
+      "left_legs": {
+        "health": 12,
+        "shapes": [
+          {
+            "type": "rect",
+            "position": [
+              7,
+              9
+            ],
+            "size": [
+              2,
+              4
+            ],
+            "color": [
+              0,
+              1,
+              0,
+              1
+            ]
+          },
+          {
+            "type": "rect",
+            "position": [
+              6,
+              13
+            ],
+            "size": [
+              2,
+              2
+            ],
+            "color": [
+              0,
+              1,
+              0,
+              1
+            ]
+          }
+        ]
+      },
+      "right_legs": {
+        "health": 12,
+        "shapes": [
+          {
+            "type": "rect",
+            "position": [
+              11,
+              9
+            ],
+            "size": [
+              2,
+              4
+            ],
+            "color": [
+              0,
+              1,
+              0,
+              1
+            ]
+          },
+          {
+            "type": "rect",
+            "position": [
+              12,
+              13
+            ],
+            "size": [
+              2,
+              2
+            ],
+            "color": [
+              0,
+              1,
+              0,
+              1
+            ]
+          }
+        ]
+      }
+    }
   },
   "mech": {
-	"size": 20,
-	"grid": "left",
-	"base_color": [
-	  0,
-	  0,
-	  0,
-	  0
-	],
-	"outline_color": [
-	  0,
-	  0,
-	  0,
-	  1
-	],
-	"shapes": {
-	  "head": [
-		{
-		  "type": "rect",
-		  "position": [
-			8,
-			2
-		  ],
-		  "size": [
-			4,
-			2
-		  ],
-		  "color": [
-			1,
-			0,
-			0,
-			1
-		  ]
-		},
-		{
-		  "type": "rect",
-		  "position": [
-			7,
-			3
-		  ],
-		  "size": [
-			1,
-			1
-		  ],
-		  "color": [
-			1,
-			0,
-			0,
-			1
-		  ]
-		},
-		{
-		  "type": "rect",
-		  "position": [
-			12,
-			3
-		  ],
-		  "size": [
-			1,
-			1
-		  ],
-		  "color": [
-			1,
-			0,
-			0,
-			1
-		  ]
-		}
-	  ],
-	  "torso": [
-		{
-		  "type": "rect",
-		  "position": [
-			7,
-			4
-		  ],
-		  "size": [
-			7,
-			2
-		  ],
-		  "color": [
-			1,
-			0,
-			0,
-			1
-		  ]
-		},
-		{
-		  "type": "rect",
-		  "position": [
-			8,
-			6
-		  ],
-		  "size": [
-			4,
-			4
-		  ],
-		  "color": [
-			1,
-			0,
-			0,
-			1
-		  ]
-		}
-	  ],
-	  "left_arm": [
-		{
-		  "type": "rect",
-		  "position": [
-			5,
-			4
-		  ],
-		  "size": [
-			2,
-			4
-		  ],
-		  "color": [
-			1,
-			0,
-			0,
-			1
-		  ]
-		},
-		{
-		  "type": "rect",
-		  "position": [
-			4,
-			8
-		  ],
-		  "size": [
-			1,
-			2
-		  ],
-		  "color": [
-			1,
-			0,
-			0,
-			1
-		  ]
-		}
-	  ],
-	  "right_arm": [
-		{
-		  "type": "rect",
-		  "position": [
-			13,
-			4
-		  ],
-		  "size": [
-			2,
-			4
-		  ],
-		  "color": [
-			1,
-			0,
-			0,
-			1
-		  ]
-		},
-		{
-		  "type": "rect",
-		  "position": [
-			15,
-			8
-		  ],
-		  "size": [
-			1,
-			2
-		  ],
-		  "color": [
-			1,
-			0,
-			0,
-			1
-		  ]
-		}
-	  ],
-	  "left_leg": [
-		{
-		  "type": "rect",
-		  "position": [
-			7,
-			10
-		  ],
-		  "size": [
-			2,
-			5
-		  ],
-		  "color": [
-			1,
-			0,
-			0,
-			1
-		  ]
-		},
-		{
-		  "type": "rect",
-		  "position": [
-			6,
-			15
-		  ],
-		  "size": [
-			2,
-			2
-		  ],
-		  "color": [
-			1,
-			0,
-			0,
-			1
-		  ]
-		}
-	  ],
-	  "right_leg": [
-		{
-		  "type": "rect",
-		  "position": [
-			11,
-			10
-		  ],
-		  "size": [
-			2,
-			5
-		  ],
-		  "color": [
-			1,
-			0,
-			0,
-			1
-		  ]
-		},
-		{
-		  "type": "rect",
-		  "position": [
-			12,
-			15
-		  ],
-		  "size": [
-			2,
-			2
-		  ],
-		  "color": [
-			1,
-			0,
-			0,
-			1
-		  ]
-		}
-	  ]
-	}
+    "size": 20,
+    "grid": "left",
+    "base_color": [
+      0,
+      0,
+      0,
+      0
+    ],
+    "outline_color": [
+      0,
+      0,
+      0,
+      1
+    ],
+    "shapes": {
+      "head": {
+        "health": 10,
+        "shapes": [
+          {
+            "type": "rect",
+            "position": [
+              8,
+              2
+            ],
+            "size": [
+              4,
+              2
+            ],
+            "color": [
+              1,
+              0,
+              0,
+              1
+            ]
+          },
+          {
+            "type": "rect",
+            "position": [
+              7,
+              3
+            ],
+            "size": [
+              1,
+              1
+            ],
+            "color": [
+              1,
+              0,
+              0,
+              1
+            ]
+          },
+          {
+            "type": "rect",
+            "position": [
+              12,
+              3
+            ],
+            "size": [
+              1,
+              1
+            ],
+            "color": [
+              1,
+              0,
+              0,
+              1
+            ]
+          }
+        ]
+      },
+      "torso": {
+        "health": 30,
+        "shapes": [
+          {
+            "type": "rect",
+            "position": [
+              7,
+              4
+            ],
+            "size": [
+              7,
+              2
+            ],
+            "color": [
+              1,
+              0,
+              0,
+              1
+            ]
+          },
+          {
+            "type": "rect",
+            "position": [
+              8,
+              6
+            ],
+            "size": [
+              4,
+              4
+            ],
+            "color": [
+              1,
+              0,
+              0,
+              1
+            ]
+          }
+        ]
+      },
+      "left_arm": {
+        "health": 10,
+        "shapes": [
+          {
+            "type": "rect",
+            "position": [
+              5,
+              4
+            ],
+            "size": [
+              2,
+              4
+            ],
+            "color": [
+              1,
+              0,
+              0,
+              1
+            ]
+          },
+          {
+            "type": "rect",
+            "position": [
+              4,
+              8
+            ],
+            "size": [
+              1,
+              2
+            ],
+            "color": [
+              1,
+              0,
+              0,
+              1
+            ]
+          }
+        ]
+      },
+      "right_arm": {
+        "health": 10,
+        "shapes": [
+          {
+            "type": "rect",
+            "position": [
+              13,
+              4
+            ],
+            "size": [
+              2,
+              4
+            ],
+            "color": [
+              1,
+              0,
+              0,
+              1
+            ]
+          },
+          {
+            "type": "rect",
+            "position": [
+              15,
+              8
+            ],
+            "size": [
+              1,
+              2
+            ],
+            "color": [
+              1,
+              0,
+              0,
+              1
+            ]
+          }
+        ]
+      },
+      "left_leg": {
+        "health": 14,
+        "shapes": [
+          {
+            "type": "rect",
+            "position": [
+              7,
+              10
+            ],
+            "size": [
+              2,
+              5
+            ],
+            "color": [
+              1,
+              0,
+              0,
+              1
+            ]
+          },
+          {
+            "type": "rect",
+            "position": [
+              6,
+              15
+            ],
+            "size": [
+              2,
+              2
+            ],
+            "color": [
+              1,
+              0,
+              0,
+              1
+            ]
+          }
+        ]
+      },
+      "right_leg": {
+        "health": 14,
+        "shapes": [
+          {
+            "type": "rect",
+            "position": [
+              11,
+              10
+            ],
+            "size": [
+              2,
+              5
+            ],
+            "color": [
+              1,
+              0,
+              0,
+              1
+            ]
+          },
+          {
+            "type": "rect",
+            "position": [
+              12,
+              15
+            ],
+            "size": [
+              2,
+              2
+            ],
+            "color": [
+              1,
+              0,
+              0,
+              1
+            ]
+          }
+        ]
+      }
+    }
   }
 }

--- a/scripts/CharacterData.gd
+++ b/scripts/CharacterData.gd
@@ -121,24 +121,22 @@ static func _draw_rect_outline(img: Image, pos: Vector2i, size: Vector2i, color:
 				img.set_pixel(x1, y, color)
 
 static func _extract_all_shapes(data: Variant) -> Array:
-	var result: Array = []
-	if data is Array:
-		for s in data:
-			if s is Dictionary:
-				result.append(s)
-	elif data is Dictionary:
-		# Support either an array of shapes or a single shape dictionary
-		if data.has("type"):
-			result.append(data)
-		else:
-			for v in data.values():
-				if v is Array:
-					for s in v:
-						if s is Dictionary:
-							result.append(s)
-				elif v is Dictionary and v.has("type"):
-					result.append(v)
-	return result
+        var result: Array = []
+        if data is Array:
+                for s in data:
+                        if s is Dictionary:
+                                result.append(s)
+        elif data is Dictionary:
+                # Support either an array of shapes or a single shape dictionary
+                if data.has("type"):
+                        result.append(data)
+                elif data.has("shapes"):
+                        result.append_array(_extract_all_shapes(data.get("shapes")))
+                else:
+                        for v in data.values():
+                                if v is Array or v is Dictionary:
+                                        result.append_array(_extract_all_shapes(v))
+        return result
 
 static func _generate_texture(desc: Dictionary) -> ImageTexture:
 	var width := int(GRID.CELL_SIZE * GRID.COLS)
@@ -298,12 +296,63 @@ static func get_grid_index(name: String) -> int:
 # the given character. If the shapes are not organized by group, the returned
 # dictionary contains a single entry with an empty string as the key.
 static func get_shape_groups(name: String) -> Dictionary:
-	_load_data()
-	if not _characters.has(name):
-		return {}
-	var shapes = _characters[name].get("shapes")
-	if typeof(shapes) == TYPE_DICTIONARY:
-		return shapes
-	elif shapes is Array:
-		return {"": shapes}
-	return {}
+        _load_data()
+        if not _characters.has(name):
+                return {}
+        var shapes = _characters[name].get("shapes")
+        if typeof(shapes) == TYPE_DICTIONARY:
+                var result: Dictionary = {}
+                for g in shapes.keys():
+                        var entry = shapes[g]
+                        if entry is Array:
+                                result[g] = entry
+                        elif entry is Dictionary:
+                                if entry.has("shapes"):
+                                        var arr = entry["shapes"]
+                                        if arr is Array:
+                                                result[g] = arr
+                                        else:
+                                                result[g] = _extract_all_shapes(arr)
+                                elif entry.has("type"):
+                                        result[g] = [entry]
+                return result
+        elif shapes is Array:
+                return {"": shapes}
+        return {}
+
+# Returns the health value for a specific group of a character. If the group
+# defines a "health" key, that value is returned. Otherwise the health is
+# calculated as the total number of squares described by the group's shapes.
+static func get_group_health(name: String, group: String) -> int:
+        _load_data()
+        if not _characters.has(name):
+                return 0
+        var shapes_dict = _characters[name].get("shapes")
+        if typeof(shapes_dict) != TYPE_DICTIONARY or not shapes_dict.has(group):
+                return 0
+        var entry = shapes_dict[group]
+        if entry is Dictionary and entry.has("health"):
+                return int(entry["health"])
+        var arr: Array = []
+        if entry is Array:
+                arr = entry
+        elif entry is Dictionary:
+                if entry.has("shapes"):
+                        var tmp = entry["shapes"]
+                        if tmp is Array:
+                                arr = tmp
+                        else:
+                                arr = _extract_all_shapes(tmp)
+                elif entry.has("type"):
+                        arr = [entry]
+        var health: int = 0
+        for s in arr:
+                if s is Dictionary:
+                        match String(s.get("type", "")):
+                                "rect":
+                                        var sz: Array = s.get("size", [0, 0])
+                                        health += int(sz[0]) * int(sz[1])
+                                "circle":
+                                        var r: float = float(s.get("radius", 0))
+                                        health += int(PI * r * r)
+        return health


### PR DESCRIPTION
## Summary
- add `health` to each group in `characters.json`
- update README to describe group health
- extend CharacterData helpers for new JSON format and group health retrieval

## Testing
- `python3 -m json.tool data/characters.json > /dev/null && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_6847a000aadc832ea23193235578b56e