### PR TITLE
Compute health from body parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ This repository contains a minimal Godot project for a simple 2D card game proto
 1. Open the folder in Godot 4.x.
 2. Run the project to see the empty scene. The left grid represents the player
    and the right grid is the enemy. Each side now displays a health counter
-   above its grid. At the start of each turn, one of the predefined attacks from
+   above its grid. The value shown is the sum of the health for every body part
+   defined in `data/characters.json`. At the start of each turn, one of the predefined attacks from
    `data/attacks.json` is chosen and those four squares on the player's grid
   light up. Any highlighted square left uncovered when the "End Turn" button is
   pressed only deals damage if that cell overlaps the mech sprite. Likewise,

--- a/scripts/CharacterData.gd
+++ b/scripts/CharacterData.gd
@@ -356,3 +356,16 @@ static func get_group_health(name: String, group: String) -> int:
                                         var r: float = float(s.get("radius", 0))
                                         health += int(PI * r * r)
         return health
+
+# Returns the sum of health values for all groups defined for a character.
+static func get_total_health(name: String) -> int:
+        _load_data()
+        if not _characters.has(name):
+                return 0
+        var shapes_dict = _characters[name].get("shapes")
+        if typeof(shapes_dict) != TYPE_DICTIONARY:
+                return 0
+        var total: int = 0
+        for g in shapes_dict.keys():
+                total += get_group_health(name, String(g))
+        return total

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -10,9 +10,8 @@ var _enemy_health_label: Label
 var _hover_label: Label
 const ENERGY_PER_TURN := 3
 var _energy_available: int = ENERGY_PER_TURN
-const STARTING_HEALTH := 10
-var _player_health: int = STARTING_HEALTH
-var _enemy_health: int = STARTING_HEALTH
+var _player_health: int = 0
+var _enemy_health: int = 0
 const HAZARDS_PER_ROUND := 4
 
 # Sprite placeholders for an alien and a mech that appear behind the grids
@@ -52,6 +51,9 @@ func _ready() -> void:
     _energy_label.position = Vector2(120, 10)
     add_child(_energy_label)
     _update_energy_label()
+
+    _player_health = CHARACTER_DATA.get_total_health("mech")
+    _enemy_health = CHARACTER_DATA.get_total_health("alien")
 
     _player_health_label = Label.new()
     add_child(_player_health_label)


### PR DESCRIPTION
## Summary
- add `get_total_health` helper in `CharacterData`
- compute player and enemy health from character data instead of fixed constant
- document how the total health is calculated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848cebe2708832eb15ef0c7aaa69752