### PR TITLE
Implement dynamic body part health

### DIFF
--- a/scripts/CharacterData.gd
+++ b/scripts/CharacterData.gd
@@ -16,6 +16,8 @@ static var _loaded := false
 static var _bounds: Dictionary = {}
 static var _offsets: Dictionary = {}
 static var _top_left_offsets: Dictionary = {}
+static var _current_health: Dictionary = {}
+static var _health_initialized := false
 
 static func _check_cell_size() -> void:
     if _last_cell_size != GRID.CELL_SIZE:
@@ -323,8 +325,7 @@ static func get_shape_groups(name: String) -> Dictionary:
 # Returns the health value for a specific group of a character. If the group
 # defines a "health" key, that value is returned. Otherwise the health is
 # calculated as the total number of squares described by the group's shapes.
-static func get_group_health(name: String, group: String) -> int:
-        _load_data()
+static func _calc_group_health(name: String, group: String) -> int:
         if not _characters.has(name):
                 return 0
         var shapes_dict = _characters[name].get("shapes")
@@ -357,15 +358,46 @@ static func get_group_health(name: String, group: String) -> int:
                                         health += int(PI * r * r)
         return health
 
+static func _initialize_health() -> void:
+        _load_data()
+        if _health_initialized:
+                return
+        for char_name in _characters.keys():
+                var groups = get_shape_groups(char_name)
+                var current: Dictionary = {}
+                for g in groups.keys():
+                        current[g] = _calc_group_health(char_name, String(g))
+                _current_health[char_name] = current
+        _health_initialized = true
+
+static func reset_health() -> void:
+        _health_initialized = false
+        _current_health.clear()
+        _initialize_health()
+
+static func damage_group(name: String, group: String, amount: int) -> void:
+        _initialize_health()
+        if not _current_health.has(name):
+                return
+        var groups: Dictionary = _current_health[name]
+        if not groups.has(group):
+                return
+        var remaining: int = max(int(groups[group]) - amount, 0)
+        groups[group] = remaining
+        _current_health[name] = groups
+
+static func get_group_health(name: String, group: String) -> int:
+        _initialize_health()
+        if _current_health.has(name) and _current_health[name].has(group):
+                return int(_current_health[name][group])
+        return 0
+
 # Returns the sum of health values for all groups defined for a character.
 static func get_total_health(name: String) -> int:
-        _load_data()
-        if not _characters.has(name):
-                return 0
-        var shapes_dict = _characters[name].get("shapes")
-        if typeof(shapes_dict) != TYPE_DICTIONARY:
+        _initialize_health()
+        if not _current_health.has(name):
                 return 0
         var total: int = 0
-        for g in shapes_dict.keys():
-                total += get_group_health(name, String(g))
+        for v in _current_health[name].values():
+                total += int(v)
         return total

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -34,6 +34,7 @@ var _shape_names: Array[String] = []
 
 func _ready() -> void:
     randomize()
+    CHARACTER_DATA.reset_health()
     _shape_names = ShapeData.get_shape_names()
     _previous_viewport_size = get_viewport_rect().size
     _grids = [get_node("LeftGrid"), get_node("RightGrid")]
@@ -176,14 +177,22 @@ func _highlight_new_round() -> void:
 func _apply_danger_damage() -> void:
     if _grids.size() < 2:
         return
-    var rect := Rect2()
-    if _mech_sprite and _mech_sprite.texture:
-        var tex_size := _mech_sprite.texture.get_size() * _mech_sprite.scale
-        rect = Rect2(_mech_sprite.global_position, tex_size)
-    var dmg := _grids[_mech_grid_idx].count_uncovered_highlights_in_rect(rect)
-    _player_health -= dmg
+    if _mech_sprite == null or _mech_sprite.texture == null:
+        return
+    var grid := _grids[_mech_grid_idx]
+    var desc := CHARACTER_DATA.get_description("mech")
+    var dmg := 0
+    for c in grid.danger_cells:
+        if grid.cells[c.x][c.y]:
+            continue
+        var center := grid.to_global(Vector2((c.x + 0.5) * Grid.CELL_SIZE, (c.y + 0.5) * Grid.CELL_SIZE))
+        var group_name := _group_at_point("mech", desc, _mech_sprite, center)
+        if group_name != "":
+            CHARACTER_DATA.damage_group("mech", group_name, 1)
+            dmg += 1
+    _player_health = CHARACTER_DATA.get_total_health("mech")
     _update_health_labels()
-    _grids[_mech_grid_idx].clear_highlights()
+    grid.clear_highlights()
 
 func _discard_remaining_cards() -> void:
     for card in _cards:
@@ -231,25 +240,15 @@ func _update_health_label_positions() -> void:
     _enemy_health_label.position = _grids[_alien_grid_idx].position + Vector2(grid_width / 2, -20)
 
 func _apply_damage(grid_idx: int, card: Card) -> void:
-    var dmg: int = 0
     if grid_idx == _alien_grid_idx and _alien_sprite and _alien_sprite.texture:
         var desc: Dictionary = CHARACTER_DATA.get_description("alien")
-        var shapes_data = desc.get("shapes", [])
-        var shapes: Array = []
-        if shapes_data is Array:
-            shapes = shapes_data
-        elif shapes_data is Dictionary:
-            shapes = CHARACTER_DATA._extract_all_shapes(shapes_data)
-        var ratio: float = float(Grid.CELL_SIZE)
-        var sprite_scale := Vector2(_alien_sprite.scale.x, _alien_sprite.scale.y)
-        var tex_size: Vector2 = _alien_sprite.texture.get_size() * sprite_scale
-        var sprite_top_left := _alien_sprite.global_position
         var blocks: Array[Vector2] = card.get_global_block_positions()
         for b in blocks:
-            var block_rect := Rect2(b, Vector2(Grid.CELL_SIZE, Grid.CELL_SIZE))
-            if _shapes_overlap_rect(shapes, sprite_top_left, ratio, sprite_scale, block_rect):
-                dmg += 1
-        _enemy_health -= dmg
+            var center := b + Vector2(Grid.CELL_SIZE / 2.0, Grid.CELL_SIZE / 2.0)
+            var group_name := _group_at_point("alien", desc, _alien_sprite, center)
+            if group_name != "":
+                CHARACTER_DATA.damage_group("alien", group_name, 1)
+        _enemy_health = CHARACTER_DATA.get_total_health("alien")
     _update_health_labels()
 
 


### PR DESCRIPTION
## Summary
- track current health for each character body part
- update damage logic to subtract from specific body parts
- reset body part health on game start

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6848d062f5c8832eae46fc7e55befe9d