### PR TITLE
Fix typed array error

### DIFF
--- a/scripts/Grid.gd
+++ b/scripts/Grid.gd
@@ -22,7 +22,9 @@ static func set_cell_size(new_size: float) -> void:
             if grid is Grid:
                 grid.queue_redraw()
 
-var cells: Array[Array[bool]] = []
+# Nested typed arrays are not supported in GDScript, so
+# use an untyped outer Array for the grid rows.
+var cells: Array = []
 var preview_cells: Array[Vector2i] = []
 var danger_cells: Array[Vector2i] = []
 


### PR DESCRIPTION
## Summary
- remove nested typed collection type annotations from `Grid.gd`

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848e63c1660832ea1ed5b100dc6b196