### PR TITLE
Fix type inference warning for num_parts

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -185,7 +185,7 @@ func _highlight_new_round() -> void:
         return
 
     living.shuffle()
-    var num_parts := min(3, living.size())
+    var num_parts: int = min(3, living.size())
     var highlight_cells: Array[Vector2i] = []
     for i in range(num_parts):
         var part := living[i]


### PR DESCRIPTION
## Summary
- fix Variant inference warning by explicitly typing `num_parts` as `int`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a1ac6cb80832e8b4139c5ac9e1aaf